### PR TITLE
Add recent job log monitor page for dashboard.

### DIFF
--- a/dashboard/recent.html
+++ b/dashboard/recent.html
@@ -1,0 +1,96 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>ArchiveBot Job Monitor Station</title>
+<link rel="stylesheet" type="text/css"
+	href="//cdn.datatables.net/1.10.2/css/jquery.dataTables.css">
+<style>
+html, body {
+	background-color: #D4D6E9;
+	color: black;
+}
+
+.cell_warn_higlight {
+	background-color: #FFC2E3 !important;
+	font-weight: bold;
+}
+</style>
+</head>
+<body>
+	<noscript>Please enable JavaScript or request this resource
+		as application/json for raw data.</noscript>
+	<table id="pipeline_table" class="display">
+		<thead>
+			<tr>
+				<th>Pipeline</th>
+				<th>Ident</th>
+				<th>Queued At</th>
+				<th>Timestamp</th>
+			</tr>
+		</thead>
+		<tbody>
+		</tbody>
+	</table>
+	<script
+		src="//ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+	<script type="text/javascript" charset="utf8"
+		src="//cdn.datatables.net/1.10.2/js/jquery.dataTables.js"></script>
+	<script type="text/javascript" src="/assets/jquery.timeago.js"></script>
+	<script>
+		var table;
+		var reloadInterval = 60 * 1000;
+		var timestampThreshold = 60 * 5 * 1000;
+		function initTable() {
+			table = $('#pipeline_table').DataTable({
+				"paging" : false,
+				"ajax" : {
+					"url" : "/logs/recent?count=1",
+					"dataSrc": ""
+				},
+				"columns" : [ {
+					"data" : "job_data.pipeline_id"
+				}, {
+					"data" : "job_data.ident"
+				}, {
+					"data" : "job_data.queued_at",
+					"createdCell" : function(td, cellData, rowData, row, col) {
+						var cellDate = new Date(cellData * 1000);
+						var dateNow = new Date();
+						
+						$(td).attr('title', cellDate.toLocaleString());
+						$(td).text(jQuery.timeago(cellDate));
+					},
+					"className" : "dateFormatable"
+				}, {
+					"data" : "ts",
+					"createdCell" : function(td, cellData, rowData, row, col) {
+						var cellDate = new Date(cellData * 1000);
+						var dateNow = new Date();
+						
+						$(td).attr('title', cellDate.toLocaleString());
+						$(td).text(jQuery.timeago(cellDate));
+						
+						if (dateNow.getTime() - cellDate.getTime() > timestampThreshold) {
+							$(td).addClass('cell_warn_higlight');
+						}
+					},
+					"className" : "dateFormatable"
+				}, ]
+			});
+
+			setTimeout(reloadTable, reloadInterval);
+
+			$('.dateFormatable').timeago();
+		}
+
+		function reloadTable() {
+			table.ajax.reload(function() {
+				setTimeout(reloadTable, reloadInterval);
+			})
+		}
+
+		$(document).ready(initTable);
+	</script>
+</body>
+</head>


### PR DESCRIPTION
Similar to #105 , this adds a graphical UI to the JSON for the recent logs. Pipeline ID, ident, queued at, and timestamp is shown. If timestamp is older than 5 minutes, it is highlighted.
