### PR TITLE
CSS fixes for beta interface height-limit

### DIFF
--- a/dashboard/dashboard3.html
+++ b/dashboard/dashboard3.html
@@ -61,12 +61,12 @@ html, body {
 
 .height-limit-small {
 	overflow: hidden;
-	height: 10em;
+	max-height: 10em;
 }
 
 .height-limit-big {
 	overflow: auto;
-	height: 20em;
+	max-height: 30em;
 }
 
 .job-summary td {


### PR DESCRIPTION
Use max-height so that in "narrow mode", it collapses
Extend height-limit-big to show the full summary (for jobs with 0 or 1 line of notes)