### PR TITLE
Ignore broken link to warnerbros.com

### DIFF
--- a/db/ignore_patterns/global.json
+++ b/db/ignore_patterns/global.json
@@ -175,7 +175,8 @@
         "^https?://([^/]+\\.)?gdcvault\\.com(/.*/|/)(fonts(/.*/|/)fonts/|css(/.*/|/)css/|img(/.*/|/)img/)",
         "^https://static\\.licdn\\.com/sc/p/com\\.linkedin\\.nux(:|%3A)nux-static-content(\\+|%2B)[\\d\\.]+/f/",
         "^https?://www\\.flickr\\.com/(explore/|photos/[^/]+/(sets/\\d+/(page\\d+/)?)?)\\d+_[a-f0-9]+(_[a-z])?\\.jpg$",
-        "^https?://static\\.licdn\\.com/sc/p/.+/f//"
+        "^https?://static\\.licdn\\.com/sc/p/.+/f//",
+        "^http://www\\.warnerbros\\.com/\\d+$"
     ],
     "type": "ignore_patterns"
 }


### PR DESCRIPTION
warnerbros.com/[number] always redirect to a 404 page.
Something on the Internet generate a lot of these links and ArchiveBot waste time getting the same error page again and again.