### PR TITLE
Fix twitter ignore set.

### DIFF
--- a/db/ignore_patterns/twitter.json
+++ b/db/ignore_patterns/twitter.json
@@ -1,7 +1,7 @@
 {
     "name": "twitter",
     "patterns": [
-        "^https?://((?:www|mobile)\\.)?twitter\\.com/.+\\?(?:id|lang|locale|screen_name)=",
+        "^https?://((?:www|mobile)\\.)?twitter\\.com/.+[\\?&](?:id|lang|locale|screen_name|nav)=",
         "^https?://mobile\\.twitter\\.com/i/anonymize\\?data="
     ],
     "type": "ignore_patterns"


### PR DESCRIPTION
This should prevent twitter jobs from endlessly downloading [\?&]nav= and other crazy stuff.