### PR TITLE
The hooked call to add_ignore_sets doesn't need to re-check authorization

### DIFF
--- a/bot/add_ignore_sets.rb
+++ b/bot/add_ignore_sets.rb
@@ -1,6 +1,6 @@
 module AddIgnoreSets
   def run_post_registration_hooks(m, job, params)
-    add_ignore_sets(m, job, params[:ignore_sets] || [])
+    add_ignore_sets(m, job, params[:ignore_sets] || [], false)
 
     super
   end


### PR DESCRIPTION
I have not tested this, as I haven't set up the environment for it yet.