### PR TITLE
Expand global tumblr ignore to cover other subdomains

### DIFF
--- a/db/ignore_patterns/global.json
+++ b/db/ignore_patterns/global.json
@@ -115,7 +115,7 @@
         "^https?://[^/]+\\.rastream\\.com(:\\d+)?/",
         "^https?://audiots\\.scdn\\.arkena\\.com/",
         "^https?://(www|draft)\\.blogger\\.com/(navbar\\.g|post-edit\\.g|delete-comment\\.g|comment-iframe\\.g|share-post\\.g|email-post\\.g|blog-this\\.g|delete-backlink\\.g|rearrange|blog_this\\.pyra)\\?",
-        "^https?://www\\.tumblr\\.com/(impixu\\?|share(/link/?)?\\?|reblog/)",
+        "^https?://[^/]*tumblr\\.com/(impixu\\?|share(/link/?)?\\?|reblog/)",
         "^https?://plus\\.google\\.com/share\\?",
         "^https?://(apis|plusone)\\.google\\.com/_/\\+1/",
         "^https?://(ssl\\.|www\\.)?reddit\\.com/(login\\?dest=|submit\\?|static/button/button)",


### PR DESCRIPTION
"^https?://www\.tumblr\.com/(impixu\?|share(/link/?)?\?|reblog/)" was failing
to match URLs such as "https://px.srvcs.tumblr.com/impixu?".

If the new ignore is too broad or inefficient, one could instead specifically match px.srvcs.tumblr.com/impixu, since that's really the only thing I see the current one missing on a regular basis.