### PR TITLE
Async shipping of logs from pipelines to redis

### DIFF
--- a/pipeline/archivebot/control.py
+++ b/pipeline/archivebot/control.py
@@ -63,7 +63,7 @@ class Control(object):
 
         self.connect()
 
-        log_thread = Thread(target=self.ship_logs, args=(self,))
+        log_thread = Thread(target=self.ship_logs)
         log_thread.daemon = True
         log_thread.start()
 

--- a/pipeline/archivebot/control.py
+++ b/pipeline/archivebot/control.py
@@ -63,7 +63,7 @@ class Control(object):
 
         self.connect()
 
-        log_thread = Thread(target=self.ship_logs, args=self)
+        log_thread = Thread(target=self.ship_logs, args=(self))
         log_thread.daemon = True
         log_thread.start()
 

--- a/pipeline/archivebot/control.py
+++ b/pipeline/archivebot/control.py
@@ -63,7 +63,7 @@ class Control(object):
 
         self.connect()
 
-        log_thread = Thread(target=self.ship_logs, args=(self))
+        log_thread = Thread(target=self.ship_logs, args=(self,))
         log_thread.daemon = True
         log_thread.start()
 

--- a/pipeline/archivebot/control.py
+++ b/pipeline/archivebot/control.py
@@ -63,9 +63,9 @@ class Control(object):
 
         self.connect()
 
-        log_thread = Thread(target=self.ship_logs)
-        log_thread.daemon = True
-        log_thread.start()
+        self.log_thread = Thread(target=self.ship_logs)
+        self.log_thread.daemon = True
+        self.log_thread.start()
 
     def connected(self):
         return self.redis is not None
@@ -195,7 +195,7 @@ class Control(object):
             entry = self.log_queue.get() #infinite blocking
             try:
                 with conn(self):
-                    self.log_script(keys=entry.keys, args=entry.args)
+                    self.log_script(keys=entry['keys'], args=entry['args'])
             except ConnectionError:
                 pass
 
@@ -204,8 +204,8 @@ class Control(object):
 
     def log(self, packet, ident, log_key):
         self.log_queue.put({'keys': [ident],
-                       'args': [json.dumps(packet), self.log_channel, log_key]
-                      })
+                            'args': [json.dumps(packet), self.log_channel, log_key]
+                          })
 
     def get_url_file(self, ident):
         try:

--- a/pipeline/pipeline.py
+++ b/pipeline/pipeline.py
@@ -51,7 +51,7 @@ if not os.environ.get('NO_SEGFAULT_340'):
         "See https://bugs.python.org/issue21435"
 
 assert WPULL_EXE, 'No usable Wpull found.'
-assert PHANTOMJS, 'PhantomJS %s was not found.' % PHANTOMJS_VERSION
+assert PHANTOMJS, 'PhantomJS %s was not found.' % PHANTOMJS_VERSIONS
 assert YOUTUBE_DL, 'No usable youtube-dl found.'
 assert 'RSYNC_URL' in env, 'RSYNC_URL not set.'
 assert 'REDIS_URL' in env, 'REDIS_URL not set.'


### PR DESCRIPTION
This lifts log line, byte count, and file count shipping to a worker thread with a queue, thus speeding up crawling considerably.  However, if the redis queue is slow, the queue may become quite long.

Also corrects a typo.