### PR TITLE
Add Semantic MediaWiki ignore patterns

### DIFF
--- a/db/ignore_patterns/mediawiki.json
+++ b/db/ignore_patterns/mediawiki.json
@@ -6,6 +6,7 @@
         "[\\?&]limit=(20|100|250|500)",
         "[\\?&]hide(minor|bots|anons|liu|myself|redirs|links|trans|patrolled)=",
         "([\\?&]title=|/)Special:(UserLogin|UserLogout|Translate|MobileFeedback|MobileOptions|RecentChangesLinked|Diff|MobileDiff)",
+        "([\\?&]title=|/)Special:(Ask|Browse|SearchByProperty|ExportRDF|PageProperty|Properties|UnusedProperties|WantedProperties|SMWAdmin|Types|URIResolver|QueryCreator)",
         "([\\?&]title=|/)Special:RecentChanges&from=\\d+",
         "([\\?&]title=|/)Special:ListFiles&dir=prev&offset=\\d+",
         "([\\?&]title=|/)Special:(ListFiles|PrefixIndex).*&amp;",


### PR DESCRIPTION
Semantic MediaWiki is a MediaWiki extension that has been getting popular.  ArchiveBot got stuck downloading a lot of cruft from one earlier.

List of Special pages to ignore lifted from https://www.semantic-mediawiki.org/wiki/Help:Blocking_robots_from_Semantic_MediaWiki_special_pages.