### PR TITLE
Add Twitter analytics ignore patterns

### DIFF
--- a/db/ignore_patterns/twitter.json
+++ b/db/ignore_patterns/twitter.json
@@ -2,7 +2,11 @@
     "name": "twitter",
     "patterns": [
         "^https?://((?:www|mobile)\\.)?twitter\\.com/.+[\\?&](?:id|lang|locale|screen_name|nav)=",
-        "^https?://mobile\\.twitter\\.com/i/anonymize\\?data="
+        "^https?://mobile\\.twitter\\.com/i/anonymize\\?data=",
+        "^https?://twitter.com/i/csp_report",
+        "^https?://analytics.twitter.com/tpm",
+        "^https?://syndication.twitter.com/i/jot/syndication",
+        "^https?://twitter.com/i/jot"
     ],
     "type": "ignore_patterns"
 }


### PR DESCRIPTION
Due to phantomjs, ArchiveBot grabs numerous copies of these.  

![2017-03-16t10 19 28-selection](https://cloud.githubusercontent.com/assets/289437/23989281/38758278-0a32-11e7-91a9-c847ef379c4a.png)
