### PR TITLE
dashboard: opt out of DNS prefetching to avoid making DNS lookups on every host

### DIFF
--- a/dashboard/dashboard.html
+++ b/dashboard/dashboard.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="referrer" content="never">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta http-equiv="x-dns-prefetch-control" content="off">
 <base target="_blank">
 <link rel="alternate" type="application/rss+xml" title="RSS Feed" href="/feed/archivebot.rss">
 <link rel="alternate" type="application/atom+xml" title="Atom Feed" href="/feed/archivebot.atom">

--- a/dashboard/dashboard3.html
+++ b/dashboard/dashboard3.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="referrer" content="never">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta http-equiv="x-dns-prefetch-control" content="off">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <base target="_blank">
 <link rel="alternate" type="application/rss+xml" title="RSS Feed" href="/feed/archivebot.rss">


### PR DESCRIPTION
Before this fix, if "Use a prediction service to load pages more quickly" was
enabled in Chrome, it would make DNS lookups on the hostname in every URL that
flew by in the dashboard.

https://www.chromium.org/developers/design-documents/dns-prefetching

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-DNS-Prefetch-Control

Credit for this commit goes to @ivan