### PR TITLE
Cache the ignoracle patterns while primary_url and primary_netloc stay constant

### DIFF
--- a/pipeline/archivebot/wpull/ignoracle.py
+++ b/pipeline/archivebot/wpull/ignoracle.py
@@ -56,6 +56,10 @@ class Ignoracle(object):
 
     patterns = []
 
+    def __init__(self):
+        self._primary = None
+        self._compiled = []
+
     def set_patterns(self, strings):
         '''
         Given a list of strings, replaces this Ignoracle's pattern state with
@@ -70,6 +74,9 @@ class Ignoracle(object):
 
             self.patterns.append(string)
 
+        self._primary = None
+        self._compiled = []
+
     def ignores(self, url_record: wpull.pipeline.item.URLRecord):
         '''
         If an ignore pattern matches the given URL, returns that pattern as a string.
@@ -78,20 +85,28 @@ class Ignoracle(object):
 
         params = parameterize_record_info(url_record)
 
-        primary_url = re.escape(params.get('primary_url') or '')
-        primary_loc = re.escape(params.get('primary_netloc') or '')
+        primaryUrl = params.get('primary_url') or ''
+        primaryNetloc = params.get('primary_netloc') or ''
+        if self._primary != (primaryUrl, primaryNetloc):
+            self._compiled = []
+            escapedPrimaryUrl = re.escape(primaryUrl)
+            escapedPrimaryNetloc = re.escape(primaryNetloc)
+            for pattern in self.patterns:
+                try:
+                    expanded = pattern.replace('{primary_url}', escapedPrimaryUrl)
+                    expanded = expanded.replace('{primary_netloc}', escapedPrimaryNetloc)
+                    compiledPattern = re.compile(expanded)
+                except re.error as error:
+                    print('Pattern %s is invalid (error: %s).  Ignored.'
+                          % (pattern, str(error)), file=sys.stderr)
+                self._compiled.append((pattern, compiledPattern))
+            self._primary = (primaryUrl, primaryNetloc)
 
-        for pattern in self.patterns:
-            try:
-                expanded = pattern.replace('{primary_url}', primary_url)
-                expanded = expanded.replace('{primary_netloc}', primary_loc)
-                match = re.search(expanded, url_record.url)
+        for pattern, compiled in self._compiled:
+            match = compiled.search(url_record.url)
 
-                if match:
-                    return pattern
-            except re.error as error:
-                print('Pattern %s is invalid (error: %s).  Ignored.'
-                      % (pattern, str(error)), file=sys.stderr)
+            if match:
+                return pattern
 
         return False
 


### PR DESCRIPTION
As discussed in the IRC over the past few days, the ignoracle's performance can be improved by caching the patterns until either `primary_netloc` or `primary_url` change. This prevents repeatedly regex-escaping the values of those variables, replacing them in the regexes, and potentially recompiling the regexes (Python's `re` module caches up to 512 patterns internally) on every single call to `Ignoracle.ignores`.

You can find a basic performance analysis of this at https://github.com/JustAnotherArchivist/ArchiveBot/tree/ignoracle-performance