### PR TITLE
[WIP] Update Ignoracle tests to use wpull 2.0 interface

### DIFF
--- a/pipeline/archivebot/wpull/ignoracle_test.py
+++ b/pipeline/archivebot/wpull/ignoracle_test.py
@@ -2,11 +2,17 @@ import unittest
 import re
 
 from .ignoracle import Ignoracle, parameterize_record_info
+from wpull.pipeline.item import URLRecord
 
 p1 = 'www\.example\.com/foo\.css\?'
 p2 = 'bar/.+/baz'
 
-@unittest.skip("Pending a fix for wpull 2.x interface")
+def urlrec(url):
+    r = URLRecord()
+    r.url = url
+
+    return r
+
 class TestIgnoracle(unittest.TestCase):
     def setUp(self):
         self.oracle = Ignoracle()
@@ -14,19 +20,22 @@ class TestIgnoracle(unittest.TestCase):
         self.oracle.set_patterns([p1, p2])
 
     def test_ignores_returns_responsible_pattern(self):
-        self.assertEqual(self.oracle.ignores('http://www.example.com/foo.css?body=1'), p1)
-        self.assertEqual(self.oracle.ignores('http://www.example.com/bar/abc/def/baz'), p2)
+        r1 = urlrec('http://www.example.com/foo.css?body=1')
+        r2 = urlrec('http://www.example.com/bar/abc/def/baz')
+
+        self.assertEqual(self.oracle.ignores(r1), p1)
+        self.assertEqual(self.oracle.ignores(r2), p2)
 
     def test_ignores_skips_invalid_patterns(self):
         self.oracle.set_patterns(['???', p2])
 
-        self.assertEqual(self.oracle.ignores('http://www.example.com/bar/abc/def/baz'), p2)
+        self.assertEqual(self.oracle.ignores(urlrec('http://www.example.com/bar/abc/def/baz')), p2)
 
     def test_ignores_supports_netloc_parameterization(self):
         pattern = '{primary_netloc}/foo\.css\?'
         self.oracle.set_patterns([pattern])
 
-        result = self.oracle.ignores('http://www.example.com/foo.css?body=1', primary_netloc='www.example.com')
+        result = self.oracle.ignores(urlrec('http://www.example.com/foo.css?body=1'))
 
         self.assertEqual(result, pattern)
 
@@ -34,7 +43,7 @@ class TestIgnoracle(unittest.TestCase):
         pattern = '{primary_netloc}{}/foo\.css\?{}'
         self.oracle.set_patterns([pattern])
 
-        result = self.oracle.ignores('http://www.example.com{}/foo.css?{}body=1', primary_netloc='www.example.com')
+        result = self.oracle.ignores(urlrec('http://www.example.com{}/foo.css?{}body=1'))
 
         self.assertEqual(result, pattern)
 
@@ -42,7 +51,7 @@ class TestIgnoracle(unittest.TestCase):
         pattern = '{primary_netloc}{1}/foo\.css\?{}'
         self.oracle.set_patterns([pattern])
 
-        result = self.oracle.ignores('http://www.example.com/foo.css?{}body=1', primary_netloc='www.example.com')
+        result = self.oracle.ignores(urlrec('http://www.example.com/foo.css?{}body=1'))
 
         self.assertEqual(result, pattern)
 
@@ -50,7 +59,7 @@ class TestIgnoracle(unittest.TestCase):
         pattern = '/(.*)/(\\1/){3,}'
         self.oracle.set_patterns([pattern])
 
-        result = self.oracle.ignores('http://www.example.com/foo/foo/foo/foo/foo')
+        result = self.oracle.ignores(urlrec('http://www.example.com/foo/foo/foo/foo/foo'))
 
         self.assertEqual(result, pattern)
 
@@ -60,7 +69,7 @@ class TestIgnoracle(unittest.TestCase):
 
         self.oracle.set_patterns([wrong, right])
 
-        result = self.oracle.ignores('http://www.example.com/foo/foo/foo/foo/foo')
+        result = self.oracle.ignores(urlrec('http://www.example.com/foo/foo/foo/foo/foo'))
 
         self.assertEqual(result, right)
 
@@ -68,7 +77,7 @@ class TestIgnoracle(unittest.TestCase):
         pattern = '{primary_url}foo\.css\?'
         self.oracle.set_patterns([pattern])
 
-        result = self.oracle.ignores('http://www.example.com/foo.css?body=1', primary_url='http://www.example.com/')
+        result = self.oracle.ignores(urlrec('http://www.example.com/foo.css?body=1'))
 
         self.assertEqual(result, pattern)
 
@@ -76,7 +85,7 @@ class TestIgnoracle(unittest.TestCase):
         pattern = '{primary_url}foo\.css\?'
         self.oracle.set_patterns([pattern])
 
-        result = self.oracle.ignores('http://www.example.com/bar.css??/foo.css?body=1', primary_url='http://www.example.com/bar.css??/')
+        result = self.oracle.ignores(urlrec('http://www.example.com/bar.css??/foo.css?body=1'))
 
         self.assertEqual(result, pattern)
 
@@ -85,53 +94,53 @@ class TestIgnoracle(unittest.TestCase):
         self.oracle.set_patterns([pattern])
 
         # This should treat the pattern as if it were "foo\.css\?"
-        result = self.oracle.ignores('http://www.example.com/foo.css?body=1')
+        result = self.oracle.ignores(urlrec('http://www.example.com/foo.css?body=1'))
 
         self.assertEqual(result, pattern)
 
     def test_ignores_returns_false_for_unsuccessful_match(self):
-        self.assertFalse(self.oracle.ignores('http://www.example.com/media/qux.jpg'))
+        self.assertFalse(self.oracle.ignores(urlrec('http://www.example.com/media/qux.jpg')))
 
     def test_set_patterns_converts_bytes_to_utf8(self):
         self.oracle.set_patterns([b'foobar'])
 
         self.assertEqual(self.oracle.patterns[0], 'foobar')
 
-@unittest.skip("Pending a fix for wpull 2.x interface")
+
 class TestRecordInfoParameterization(unittest.TestCase):
-    def test_uses_top_url_if_present(self):
-        record_info = dict(
-            top_url='http://www.example.com/'
-        )
-
-        result = parameterize_record_info(record_info)
-
-        self.assertEqual('http://www.example.com/', result['primary_url'])
-        self.assertEqual('www.example.com', result['primary_netloc'])
-
     def test_uses_url_for_level_zero_url(self):
-        record_info = dict(
-            url='http://www.example.com/',
-            level=0
-        )
+        record = URLRecord()
+        record.url = 'http://www.example.com/'
+        record.level = 0
 
-        result = parameterize_record_info(record_info)
+        result = parameterize_record_info(record)
 
         self.assertEqual('http://www.example.com/', result['primary_url'])
         self.assertEqual('www.example.com', result['primary_netloc'])
+
+    def test_uses_parent_url_for_higher_level_urls(self):
+        record = URLRecord()
+        record.parent_url = 'http://www.example.com/'
+        record.url = 'http://www.example.com/foobar'
+        record.level = 1
+
+        result = parameterize_record_info(record)
+
+        self.assertEqual('http://www.example.com/', result['primary_url'])
+        self.assertEqual('www.example.com', result['primary_netloc'])
+
 
     def test_missing_primary_url_results_in_no_netloc(self):
-        result = parameterize_record_info(dict())
+        result = parameterize_record_info(URLRecord())
 
         self.assertIsNone(result['primary_url'])
         self.assertIsNone(result['primary_netloc'])
 
     def test_includes_auth_and_port_in_primary_netloc(self):
-        record_info = dict(
-            url='http://foo:bar@www.example.com:8080/',
-            level=0
-        )
+        record = URLRecord()
+        record.url = 'http://foo:bar@www.example.com:8080/'
+        record.level = 0
 
-        result = parameterize_record_info(record_info)
+        result = parameterize_record_info(record)
 
         self.assertEqual('foo:bar@www.example.com:8080', result['primary_netloc'])


### PR DESCRIPTION
This PR re-enables the ignoracle tests and ports them to use the `Ignoracle` wpull 2 interface.

It looks like they also caught a bug in the port:

```
$ nosetests
...........Pattern ??? is invalid (error: nothing to repeat at position 0).  Ignored.
.......Pattern {primary_netloc}{1}/foo\.css\?{} is invalid (error: nothing to repeat at position 0).  Ignored.
F........
======================================================================
FAIL: test_permits_empty_brace_pairs_and_regex_repetitions (archivebot.wpull.ignoracle_test.TestIgnoracle)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/trythil/prj/ArchiveTeam/ArchiveBot/pipeline/archivebot/wpull/ignoracle_test.py", line 56, in test_permits_empty_brace_pairs_and_regex_repetitions
    self.assertEqual(result, pattern)
AssertionError: False != '{primary_netloc}{1}/foo\\.css\\?{}'

----------------------------------------------------------------------
Ran 27 tests in 0.057s

FAILED (failures=1)
```

I'm holding off merging until I can investigate that test failure further.