### PR TITLE
Replace ignore pattern causing all previous revisions of wiki pages to be ignored

### DIFF
--- a/db/ignore_patterns/mediawiki.json
+++ b/db/ignore_patterns/mediawiki.json
@@ -1,7 +1,7 @@
 {
     "name": "mediawiki",
     "patterns": [
-        "[\\?&]oldid=\\d+",
+        "[\\?&]diff=\\d+",
         "[\\?&]curid=\\d+",
         "[\\?&]limit=(20|100|250|500)",
         "[\\?&]hide(minor|bots|anons|liu|myself|redirs|links|trans|patrolled)=",

--- a/db/ignore_patterns/mediawiki.json
+++ b/db/ignore_patterns/mediawiki.json
@@ -1,7 +1,8 @@
 {
     "name": "mediawiki",
     "patterns": [
-        "[\\?&]diff=\\d+",
+        "[\\?&]diff=(prev|next|cur|\\d+)",
+        "[\\?&]direction=(prev|next)&oldid=\\d+",
         "[\\?&]curid=\\d+",
         "[\\?&]limit=(20|100|250|500)",
         "[\\?&]hide(minor|bots|anons|liu|myself|redirs|links|trans|patrolled)=",


### PR DESCRIPTION
The current mediawiki ignore set includes an ignore for `oldid=\d+`. This means that only the current version of each wiki page is archived. However, the previous versions typically contain unique data which is not grabbed elsewhere, so this seems overzealous to me.

My suggestion is to replace this ignore with `diff=\d+`. This would archive old revisions, e.g. http://archiveteam.org/index.php?title=ArchiveBot&oldid=28812 (rendered) and http://archiveteam.org/index.php?title=ArchiveBot&action=edit&oldid=28812 (markup), but continue to ignore the diffs, e.g. http://archiveteam.org/index.php?title=ArchiveBot&diff=28812&oldid=28218, which can be reconstructed from the individual revisions and inflate the archive massively.