### PR TITLE
Use autossh in place of ssh

### DIFF
--- a/INSTALL.pipeline
+++ b/INSTALL.pipeline
@@ -15,7 +15,8 @@ Quick install, for Debian and Debian-esque systems like Ubuntu:
     sudo apt-get install build-essential python3-dev python3-pip \
       libxml2-dev libxslt-dev zlib1g-dev libssl-dev libsqlite3-dev \
       libffi-dev git tmux fontconfig-config fonts-dejavu-core \
-      libfontconfig1 libjpeg-turbo8 libjpeg8 lsof ffmpeg youtube-dl
+      libfontconfig1 libjpeg-turbo8 libjpeg8 lsof ffmpeg youtube-dl \
+      autossh
     pip3 install --upgrade pip
 
 NOTE: Installing phantomjs from apt will often not work on newer 
@@ -76,7 +77,7 @@ actually has.
 
 As user archivebot, in the FIRST tmux session:
 
-    ssh -C -L 127.0.0.1:16379:127.0.0.1:6379 \
+    autossh -C -L 127.0.0.1:16379:127.0.0.1:6379 \
       YOUR-USERNAME-GOES-HERE@archivebot.at.ninjawedding.org -N
 
 


### PR DESCRIPTION
Makes the setup more robust against network problems and ninjawedding downtime.