### PR TITLE
Support storing files on ZFS

### DIFF
--- a/pipeline/archivebot/dupespotter/dupes.py
+++ b/pipeline/archivebot/dupespotter/dupes.py
@@ -52,7 +52,8 @@ class DupesOnDisk(object):
         with tempfile.NamedTemporaryFile(dir=os.getcwd()) as file:
             file.truncate(1000000)
 
-            return os.stat(file.name).st_blocks == 0
+            # ZFS will take one block. Most other filesystems 0.
+            return os.stat(file.name).st_blocks < 2
 
 
 class DupesInMemory(object):


### PR DESCRIPTION
ZFS (At least the 0.6.5.6 version included with Ubuntu) will return st_blocks == 1 for all sizes of truncations I tested. Checking for <2 makes is possible to run a pipeline on ZFS.