### PR TITLE
Added some ignore patterns for tracking links and pixels on Reddit

### DIFF
--- a/db/ignore_patterns/reddit.json
+++ b/db/ignore_patterns/reddit.json
@@ -16,7 +16,10 @@
         "^https?://simple\\.reddit\\.com/",
         "^https?://pixel\\.redditmedia\\.com/pixel/",
         "\\.reddit\\.com/message/compose/?\\?",
-        "^https?://m\\.reddit\\.com/"
+        "^https?://m\\.reddit\\.com/",
+        "^https?://www\\.reddit\\.com/r/[^/]+/comments/[0-9a-z]+/[^/]+/\\?utm_content=(thumbnail|title|comments)(?!.*&(?!utm_))",
+        "^https?://amp\\.reddit\\.com/pixel\\?",
+        "^https?://www\\.reddit\\.com/[^?]+\\?(.*&)?ref=readnext(&|$)"
     ],
     "type": "ignore_patterns"
 }


### PR DESCRIPTION
Three new ignore patterns for the Reddit ignore set that I've been using manually for a while now.

* The first pattern ignores links to threads that only have UTM parameters. These come from an attribute `data-inbound-url` on thread links when you browse a subreddit. The same link without the UTM parameters can always be found in the `href` and `data-href-url` attributes on the same element, so these are just duplicates. However, it would be better to do this with a URL rewrite to remove the UTM parameters.
* The second pattern ignores some tracking pixels on the AMP version of Reddit. I'm not sure if we maybe want to ignore the AMP version entirely, but we can certainly ignore the tracking pixel.
* The third pattern ignores links that appear in a small box in the bottom right corner when you browse Reddit. They point to the next thread in the subreddit and are therefore somewhat similar to the "next topic" ignores we have in the forums igset. I've also seen some `ref=readnext` links that point back to the subreddit (i.e. the thread list). I haven't come across a single useful (i.e. non-duplicate) link with this attribute so far. But just like for the first pattern I added, it'd be better to rewrite the URLs.