### PR TITLE
Ignore VKontakte share link also on vk.com domain

### DIFF
--- a/db/ignore_patterns/global.json
+++ b/db/ignore_patterns/global.json
@@ -154,7 +154,7 @@
         "^http://wow\\.ya\\.ru/posts_(add|share)_link\\.xml\\?",
         "^https?://connect\\.mail\\.ru/share\\?",
         "^http://zakladki\\.yandex\\.ru/newlink\\.xml\\?",
-        "^https?://vkontakte\\.ru/share\\.php\\?",
+        "^https?://(vkontakte\\.ru|vk\\.com)/share\\.php\\?",
         "^https?://www\\.odnoklassniki\\.ru/dk\\?st\\.cmd=addShare",
         "^https?://www\\.google\\.com/(reader/link\\?|buzz/post\\?)",
         "^https?://service\\.weibo\\.com/share/share\\.php\\?",


### PR DESCRIPTION
VKontakte has migrated from `vkontakte.ru` to `vk.com` several years ago, but we're still only ignoring share links for the old domain.