### PR TITLE
Ignore verification code/captcha on SMF which causes an infinite loop

### DIFF
--- a/db/ignore_patterns/forums.json
+++ b/db/ignore_patterns/forums.json
@@ -42,6 +42,7 @@
         "/index\\.php\\?topic=\\d+\\.msg\\d+",
         "/index\\.php.*;wap2",
         "/index\\.php\\?action=calendar",
+        "/index\\.php\\?action=verificationcode;rand=[0-9a-f]{32};vid=search;format=\\.wav(;sound)?$",
         "/viewtopic\\.php\\?p=\\d+",
         "/viewtopic\\.php\\?f=\\d+&t=\\d+&p=\\d+",
         "/showpost\\.php\\?p=\\d+",


### PR DESCRIPTION
Simple Machines Forum's search (I think) has a captcha. The audio version of that captcha causes an infinite loop due to a `rand` parameter. Jobs 9kefnmifdalhkf9ycnznkbzsg and 6xr98h5jt8pcq0mif5ebv49l7 were affected by this, for example.