### PR TITLE
Merge noonion igset into global igset

### DIFF
--- a/db/ignore_patterns/global.json
+++ b/db/ignore_patterns/global.json
@@ -191,7 +191,8 @@
         "^https?://[^.]+\\.pinterest\\.[^/]+/join/",
         "\\?wordfence_logHuman=1",
         "^https?://[^/]*tumblr\\.com/widgets/share/tool",
-        "amp;amp;"
+        "amp;amp;",
+        "^https?://[^/]+\\.onion/"
     ],
     "type": "ignore_patterns"
 }

--- a/db/ignore_patterns/noonion.json
+++ b/db/ignore_patterns/noonion.json
@@ -1,7 +1,0 @@
-{
-    "name": "noonion",
-    "patterns": [
-        "^https?://[^/]+\\.onion/"
-    ],
-    "type": "ignore_patterns"
-}


### PR DESCRIPTION
I propose merging the noonion ignore set, which ignores `.onion` domains, into the global ignore set. Tor is not supported by any pipeline currently anyway, and even if it were implemented, we'd have to treat them specially anyway since we (for performance reasons) most likely wouldn't want to retrieve everything in a job through Tor but only hidden services.