### PR TITLE
Ignore links by the Wordpress plugin "Super Socializer"

### DIFF
--- a/db/ignore_patterns/blogs.json
+++ b/db/ignore_patterns/blogs.json
@@ -29,7 +29,8 @@
         "^http://[^\\.]+\\.livejournal\\.com/.+http://[^\\.]+\\.livejournal\\.com/",
         "^http://[^\\.]+\\.livejournal\\.com/.+/stats\\.g\\.doubleclick\\.net/dc\\.js$",
         "^https?://www\\.dreamwidth\\.org/tools/(memadd|tellafriend)\\?",
-        "^https?://[^\\.]+\\.dreamwidth\\.org/.+[\\?&]mode=reply"
+        "^https?://[^\\.]+\\.dreamwidth\\.org/.+[\\?&]mode=reply",
+        "[?&]SuperSocializerAuth=(LiveJournal|Twitch|Twitter|Xing)(&|$)"
     ],
     "type": "ignore_patterns"
 }


### PR DESCRIPTION
Super Socializer is a Wordpress plugin for integration of what they call "Social Login, Social Share and Social Comments". This ignore handles login URLs for LiveJournal, Twitch, Twitter, and Xing. Although the plugin apparently also supports login through Facebook, Google, Instagram, Linkedin, Steam, and Vkontakte, I wasn't able to find any such URLs. It's possible it directly inserts links to those platforms instead (e.g. `https://www.facebook.com/dialog/oauth`; cf. #278) rather than using the SuperSocializerAuth URL parameter, but I didn't check.

More information on the plugin can be found at https://wordpress.org/plugins/super-socializer/.