### PR TITLE
Add !ug as an alias for !unignore

### DIFF
--- a/bot/command_patterns.rb
+++ b/bot/command_patterns.rb
@@ -10,6 +10,6 @@ module CommandPatterns
   SET_DELAY         = %r{\A\!d(?:elay)?\s+(#{IDENT})\s+(#{DELAY_SPEC})\s+(#{DELAY_SPEC})\s*\Z}
   SET_CONCURRENCY   = %r{\A\!con(?:currency)?\s+(#{IDENT})\s+(\d{1,2})\s*\Z}
   IGNORE            = %r{\A!ig(?:nore)?\s+(#{IDENT})\s+([^\s]+)\s*\Z}
-  UNIGNORE          = %r{\A!unig(?:nore)?\s+(#{IDENT})\s+([^\s]+)\s*\Z}
+  UNIGNORE          = %r{\A!(?:ug|unig(?:nore)?)\s+(#{IDENT})\s+([^\s]+)\s*\Z}
   WHEREIS           = %r{\A!w(?:hereis)?\s+(#{IDENT})\s*\Z}
 end

--- a/doc/commands.rst
+++ b/doc/commands.rst
@@ -371,7 +371,7 @@ Examples
 unignore
 ========
 
-``!unignore IDENT PATTERN``, ``!unig IDENT PATTERN``
+``!unignore IDENT PATTERN``, ``!unig IDENT PATTERN``, ``!ug IDENT PATTERN``
     remove an ignore pattern::
 
         > !unig 1q2qydhkeh3gfnrcxuf6py70b obnoxious\?foo=\d+


### PR DESCRIPTION
Motivation: IRC crops long lines at a certain number of characters. If you add a too long pattern with !ig, it is impossible to remove it again because the line with !unig would be two characters too long. This alias works around that.

Cf. #218