### PR TITLE
Add ignore for new Wordfence URL parameter wordfence_lh

### DIFF
--- a/db/ignore_patterns/global.json
+++ b/db/ignore_patterns/global.json
@@ -194,7 +194,7 @@
         "^https?://tm\\.uol\\.com\\.br/h/.+/h/",
         "^https?://media\\.opb\\.org/clips/embed/.+\\.js$",
         "^https?://[^.]+\\.pinterest\\.[^/]+/join/",
-        "\\?wordfence_logHuman=1",
+        "\\?wordfence_(logHuman|lh)=1",
         "^https?://[^/]*tumblr\\.com/widgets/share/tool",
         "amp;amp;",
         "^https?://accounts\\.google\\.com/o/oauth2/auth\\?",


### PR DESCRIPTION
The URL parameter for the Wordpress plugin Wordfence was renamed from `wordfence_logHuman` to `wordfence_lh` recently. It doesn't appear to be mentioned in the changelog or any other easily discoverable document, but it's mentioned e.g. [here](https://wordpress.org/support/topic/wordfence_loghuman1hid/).