### PR TITLE
Ignore /www/www/... recursion on recursive YouTube channel jobs

### DIFF
--- a/db/ignore_patterns/youtube.json
+++ b/db/ignore_patterns/youtube.json
@@ -2,7 +2,8 @@
     "name": "youtube",
     "patterns": [
         "^https?://accounts\\.google\\.com/ServiceLogin",
-        "\\.?youtube\\.com/user/[^/]+/(playlists|channels|videos)\\?(flow|view|sort|live_view)="
+        "\\.?youtube\\.com/user/[^/]+/(playlists|channels|videos)\\?(flow|view|sort|live_view)=",
+        "^https?://www\\.youtube\\.com/.*/www/www/"
     ],
     "type": "ignore_patterns"
 }


### PR DESCRIPTION
`!a` jobs for YouTube channels cause a recursion of www/www/www/www/www/... in the URLs. I haven't investigated where these come from, but we obviously don't want to grab them. For examples, see jobs 5i6xcnc3rbrw8atobna6zka5, c6oh9o424ia10gyraobqqh809, 8ukvohrhbx6syifk8va0kzhp9, and many more in early September.