### PR TITLE
Ignore higher resolution of Tumblr note avatars

### DIFF
--- a/db/ignore_patterns/notumblrnoteavatars.json
+++ b/db/ignore_patterns/notumblrnoteavatars.json
@@ -1,7 +1,7 @@
 {
     "name": "notumblrnoteavatars",
     "patterns": [
-        "^https?://\\d+\\.media\\.tumblr\\.com/avatar_.*_16\\.png$"
+        "^https?://\\d+\\.media\\.tumblr\\.com/avatar_.*_(16|64)\\.png$"
     ],
     "type": "ignore_patterns"
 }


### PR DESCRIPTION
Tumblr increased the resolution of note avatars at some point in the past few months from 16 x 16 px² to 64 x 64 px² on some stylesheets.
Unfortunately, this change has the side effect that the blogger's avatar might also be ignored on some pages. For example on [this blog](https://constable-frozen.tumblr.com/), the avatar appears as `_64.png` on the individual posts; however, it is also included as `_128.png` at the top of the page.
The only way to solve this properly would be to have conditional ignores depending on where on the page the image was found. I suppose this could be implemented in the `dupespotter`, similarly to the (currently broken) Drupal handling, but that would obviously be a lot more work.