### PR TITLE
Ignore PrefixIndex and WhatLinksHere recursions on MediaWiki

### DIFF
--- a/db/ignore_patterns/mediawiki.json
+++ b/db/ignore_patterns/mediawiki.json
@@ -20,6 +20,7 @@
         "[\\?&]mobileaction=",
         "[\\?&]undo(after)?=\\d+",
         "^http://a\\.wikia-beacon\\.com/__track/",
+        "([\\?&]title=|/)Special:(PrefixIndex|WhatLinksHere)/.*/\\2/",
         "/User_talk:.+/User_talk:",
         "/User_blog:.+/User_blog:",
         "/User:.+/User:",


### PR DESCRIPTION
Special:PrefixIndex and Special:WhatLinksHere frequently cause recursion issues. What seems to happen is that there's a "what links here" link for the "what links here" pages, and similarly for the prefix indices. This might be a bug in certain versions of MediaWiki, but I haven't investigated further. Example jobs: dnyx2b04lif80aihvbfp9i6bc, de08ci8z5t22lkysv4ig7mcx1, dud6zbw6dh2m8ials08bdnf7k.