### PR TITLE
Remove unnecessary rsync options in the uploader due to permission issues in some configurations and for simplicity

### DIFF
--- a/uploader/uploader.py
+++ b/uploader/uploader.py
@@ -229,7 +229,7 @@ def main():
 
                 if params.mode == 'rsync':
                     exit_code = subprocess.call([
-                        "rsync", "-av", "--timeout=300", "--contimeout=300",
+                        "rsync", "-tv", "--timeout=300", "--contimeout=300",
                         "--progress", fname_u, params.url])
                 elif params.mode == 's3':
                     exit_code = ia_s3_ship(fname_u, basename, item, params)


### PR DESCRIPTION
The uploader used `-a`, i.e. `-rlptgoD`. All except `-t` were removed for the following reasons:

* `-r`: recusion isn't needed since each file is transferred individually anyway.
* `-l` and `-D`: all files we're transferring are regular files; support for symlinks and devices isn't needed.
* `-g` and `-o`: these cause issues if the files are owned by root:root on the pipeline machine. This can happen in particular in a Docker-based setup.
* `-p`: permissions are likewise unnecessary to transfer. Note that the uploads from within the pipeline (JSONs and WARCs in the case of crashed or killed wpull processes) never copied permissions to begin with; those use seesaw's RsyncUpload, which passes the options `-rltvz` to rsync.

Keeping the date of last modification of the file may be useful, even though it is probably not used at this time. Therefore, `-t` is kept for now.