### PR TITLE
Add ignores for Radio France's streams (France Info/Inter/Culture/Musique/Bleu, FIP, and Mouv')

### DIFF
--- a/db/ignore_patterns/global.json
+++ b/db/ignore_patterns/global.json
@@ -201,7 +201,7 @@
         "^https?://[^/]+\\.onion/",
         "http://connect\\.qq\\.com/widget/shareqq/index\\.html\\?",
         "^https?://web\\.whatsapp\\.com/send\\?",
-        "^https?://(direct\\.(france(info|inter|culture|musique|bleu)|fipradio|mouv)\\.fr|(aechai9hib|chai5she)\\.cdn\\.dvmr\\.fr(:\\d+)?)/.*\\.mp3$"
+        "^https?://(direct\\.(france(info|inter|culture|musique|bleu)|fipradio|mouv)\\.fr|[^/.]+\\.cdn\\.dvmr\\.fr(:\\d+)?)/.*\\.mp3$"
     ],
     "type": "ignore_patterns"
 }

--- a/db/ignore_patterns/global.json
+++ b/db/ignore_patterns/global.json
@@ -200,7 +200,8 @@
         "^https?://www\\.facebook\\.com/dialog/oauth\\?",
         "^https?://[^/]+\\.onion/",
         "http://connect\\.qq\\.com/widget/shareqq/index\\.html\\?",
-        "^https?://web\\.whatsapp\\.com/send\\?"
+        "^https?://web\\.whatsapp\\.com/send\\?",
+        "^https?://(direct\\.(france(info|inter|culture|musique|bleu)|fipradio|mouv)\\.fr|(aechai9hib|chai5she)\\.cdn\\.dvmr\\.fr(:\\d+)?)/.*\\.mp3$"
     ],
     "type": "ignore_patterns"
 }


### PR DESCRIPTION
These streams seem to appear absolutely everywhere and have slowed down many a job before.

While I've only seen France Info, France Inter, and France Culture on ArchiveBot before, I decided to throw in the other Radio France stations as well.

The second part of the regex covers the CDN that actually hosts the streams; the URLs on direct.franceinfo.fr etc. are just redirects. Note that there are two separate streams: `/live/...` redirects to `chai5she.cdn.dvmr.fr`, `/ts/...` to `aechai9hib.cdn.dvmr.fr`. Examples:

* http://direct.franceinter.fr/live/franceinter-midfi.mp3 → http://chai5she.cdn.dvmr.fr:80/franceinter-midfi.mp3
* https://direct.franceinter.fr/ts/franceinter-midfi.mp3 → https://aechai9hib.cdn.dvmr.fr:443/franceinter-midfi.mp3