### PR TITLE
Ignore sinkhole domain

### DIFF
--- a/db/ignore_patterns/global.json
+++ b/db/ignore_patterns/global.json
@@ -201,7 +201,8 @@
         "^https?://[^/]+\\.onion/",
         "http://connect\\.qq\\.com/widget/shareqq/index\\.html\\?",
         "^https?://web\\.whatsapp\\.com/send\\?",
-        "^https?://(direct\\.(france(info|inter|culture|musique|bleu)|fipradio|mouv)\\.fr|[^/.]+\\.cdn\\.dvmr\\.fr(:\\d+)?)/.*\\.mp3$"
+        "^https?://(direct\\.(france(info|inter|culture|musique|bleu)|fipradio|mouv)\\.fr|[^/.]+\\.cdn\\.dvmr\\.fr(:\\d+)?)/.*\\.mp3$",
+        "^https?://www\\.testtesttest\\.com/"
     ],
     "type": "ignore_patterns"
 }


### PR DESCRIPTION
This domain is a sinkhole domain. IPs accessing it end up on a blacklist, specifically the CBL.
jap-porpoise was affected by this (but is now delisted). I haven't checked other pipelines' IP addresses.