### PR TITLE
make job status less chatty

### DIFF
--- a/bot/job_status_generation.rb
+++ b/bot/job_status_generation.rb
@@ -21,7 +21,6 @@ module JobStatusGeneration
     elsif in_progress?
       rep << "In progress.  Downloaded #{mb_downloaded.round(2)} MB, #{error_count.to_i} errors encountered, #{item_count} items queued."
       rep << "#{concurrency.to_i} workers, delay: [#{delay_min.to_f}, #{delay_max.to_f}] ms."
-      rep << "See the ArchiveBot dashboard for more information."
     end
 
     if (t = ttl) && (t != -1)

--- a/bot/job_status_generation.rb
+++ b/bot/job_status_generation.rb
@@ -19,7 +19,7 @@ module JobStatusGeneration
     elsif pending?
       rep << "In queue."
     elsif in_progress?
-      rep << "In progress. Downloaded #{mb_downloaded.round(2)} MB, #{error_count.to_i} errors, #{item_count} queued."
+      rep << "In progress. Downloaded #{mb_downloaded.round(2)} MiB, #{error_count.to_i} errors, #{item_count} queued."
       rep << "#{concurrency.to_i} workers, delay: #{delay_min.to_f}, #{delay_max.to_f} ms."
     end
 
@@ -33,7 +33,7 @@ module JobStatusGeneration
   private
 
   def mb_downloaded
-    bytes_downloaded.to_f / (1000 * 1000)
+    bytes_downloaded.to_f / (1024 * 1024)
   end
 
   def item_count

--- a/bot/job_status_generation.rb
+++ b/bot/job_status_generation.rb
@@ -2,7 +2,7 @@ module JobStatusGeneration
   def to_status
     rep = []
 
-    rep << "Job #{ident} <#{url}>:"
+    rep << "Job #{ident} <#{url}>."
 
     if started_by
       if note
@@ -19,15 +19,15 @@ module JobStatusGeneration
     elsif pending?
       rep << "In queue."
     elsif in_progress?
-      rep << "In progress.  Downloaded #{mb_downloaded.round(2)} MB, #{error_count.to_i} errors encountered, #{item_count} items queued."
-      rep << "#{concurrency.to_i} workers, delay: [#{delay_min.to_f}, #{delay_max.to_f}] ms."
+      rep << "In progress. Downloaded #{mb_downloaded.round(2)} MB, #{error_count.to_i} errors, #{item_count} queued."
+      rep << "#{concurrency.to_i} workers, delay: #{delay_min.to_f}, #{delay_max.to_f} ms."
     end
 
     if (t = ttl) && (t != -1)
       rep << "Eligible for rearchival in #{formatted_ttl(t)}."
     end
 
-    rep
+    [rep.join(" ")]
   end
 
   private


### PR DESCRIPTION
The job status is currently two verbose and spams the channel with four lines of log.

So instead of:

```
09:45:53 <+anarcat> !status 1wm191rekoxp02guomaxcwrpz
09:45:53 <Major> anarcat: Job 1wm191rekoxp02guomaxcwrpz <http://www.threehundredeight.com/>:
09:45:53 <Major> anarcat: Started by anarcat.
09:45:53 <Major> anarcat: In progress.  Downloaded 10915.47 MB, 1187 errors encountered, 0 items queued.
09:45:53 <Major> anarcat: 4 workers, delay: [0.0, 0.0] ms.
09:45:53 <Major> anarcat: See the ArchiveBot dashboard for more information.
```

We should be seeing something like:

```
09:45:53 <+anarcat> !status 1wm191rekoxp02guomaxcwrpz
09:45:53 <Major> anarcat: Job 1wm191rekoxp02guomaxcwrpz <http://www.threehundredeight.com/>. Started by anarcat. In progress. Downloaded 10915.47 MB, 1187 errors encountered, 0 items queued. 4 workers, delay: [0.0, 0.0] ms.
```

Untested: ideally, we'd just return a string instead of an array here, but I'm trying to respect the existing API to avoid breaking too much stuff. But I did test that the bot framework correctly splits long lines: cinch handles that fine.

We also remove the dashboard reference because it is noisy for nothing - it's already in the channel topic and it's not used in other commands which might also need it (e.g. plain `!status`).

While we here, switch to using MiB to be consistent with dashboard and the rest of the universe.