### PR TITLE
Disable youtube-dl until #291 is fixed

### DIFF
--- a/bot/brain.rb
+++ b/bot/brain.rb
@@ -61,6 +61,12 @@ class Brain
       return
     end
 
+    # youtube-dl is broken: https://github.com/ArchiveTeam/ArchiveBot/issues/291
+    if h[:youtube_dl]
+      reply m, 'Sorry, youtube-dl is broken at the moment.'
+      return
+    end
+
     # Recursive retrieval with youtube-dl is bad juju.
     if h[:youtube_dl] && depth == :inf
       reply m, 'Sorry, recursive retrieval with youtube-dl is not supported at this time.'


### PR DESCRIPTION
`--youtube-dl` has been broken since May 2017, cf. #291. This errors out when someone tries to use it.