### PR TITLE
Extend a variety of bot messages to include the job ID

### DIFF
--- a/bot/brain.rb
+++ b/bot/brain.rb
@@ -119,13 +119,13 @@ class Brain
       urls_in = 'URLs in ' if url_file
 
       if depth == :shallow
-        reply m, "Queued #{urls_in}#{uri.to_s} for archival without recursion."
+        reply m, "Queued #{urls_in}#{uri.to_s} for archival without recursion as job #{job.ident}."
       else
-        reply m, "Queued #{urls_in}#{uri.to_s}."
+        reply m, "Queued #{urls_in}#{uri.to_s} as job #{job.ident}."
       end
 
       if user_agent
-        reply m, "Using user-agent #{user_agent}."
+        reply m, "Using user-agent #{user_agent} on job #{job.ident}."
       end
 
       reply m, "Use !status #{job.ident} for updates, !abort #{job.ident} to abort."
@@ -202,7 +202,7 @@ class Brain
     return unless authorized?(m)
 
     job.abort
-    reply m, "Initiated abort for #{job.url}."
+    reply m, "Initiated abort of job #{job.ident} for #{job.url}."
   end
 
   def add_ignore_pattern(m, job, pattern)

--- a/bot/finish_message_generation.rb
+++ b/bot/finish_message_generation.rb
@@ -13,9 +13,9 @@ module FinishMessageGeneration
       by_user.each do |user, infos|
         infos.each do |info|
           if info['aborted']
-            list << "#{user}: Your job for #{info['url']} was aborted."
+            list << "#{user}: Your job #{info['ident']} for #{info['url']} was aborted."
           else
-            list << "#{user}: Your job for #{info['url']} has finished."
+            list << "#{user}: Your job #{info['ident']} for #{info['url']} has finished."
           end
         end
       end

--- a/bot/pipeline_options.rb
+++ b/bot/pipeline_options.rb
@@ -32,7 +32,7 @@ module PipelineOptions
     end
 
     if !messages.empty?
-      reply m, "Options: #{messages.join('; ')}"
+      reply m, "Options for job #{job.ident}: #{messages.join('; ')}"
     end
 
     super

--- a/doc/commands.rst
+++ b/doc/commands.rst
@@ -216,8 +216,8 @@ Accepted parameters
 
       > !archiveonly https://example.website/fun-video-38214 --youtube-dl
       < Queued https://example.website/fun-video-38214 for archival without
-        recursion.
-      < Options: youtube-dl: yes
+        recursion as job dma5g7xcy0r3gbmisqshkpkoe.
+      < Options for job dma5g7xcy0r3gbmisqshkpkoe: youtube-dl: yes
       < Use !status dma5g7xcy0r3gbmisqshkpkoe for updates, !abort
         dma5g7xcy0r3gbmisqshkpkoe to abort.
 


### PR DESCRIPTION
Some messages by the IRC bot currently don't include the job ID. This makes it harder to reconstruct what a job was doing exactly, e.g. when it needs to be requeued, since you can't just grep all lines relevant to a particular job from the IRC logs. This PR fixes that. (Untested, but I think it should work.)