### PR TITLE
document the archive --large flag

### DIFF
--- a/doc/commands.rst
+++ b/doc/commands.rst
@@ -138,6 +138,10 @@ Accepted parameters
     alias for ``!concurrency``
     sets number of workers for job (use with care!)
 
+``--large``
+    Job includes many large (>500MB) files. Job will be sent to
+    pipelines that define the `LARGE` environment.
+
 abort
 =====
 


### PR DESCRIPTION
It's in the source but not in the docs.