### PR TITLE
Allow only opped users to add jobs when there is a queue of 5 or more jobs

### DIFF
--- a/bot/brain.rb
+++ b/bot/brain.rb
@@ -46,6 +46,12 @@ class Brain
       if url_file
         return unless op?(m)
       end
+
+      # Allow only ops to add jobs to the queue if there are 5 or more jobs pending
+      if redis.llen('pending') >= 5 && !op?(m)
+        reply m, "Sorry, all pipelines are currently full, and only opped users can add to the queue beyond 5 pending. Please try again later."
+        return
+      end
     end
 
     uri = Addressable::URI.parse(target).normalize


### PR DESCRIPTION
The job queue used to be disabled entirely until that restriction was removed last year due to the [observation](https://github.com/ArchiveTeam/ArchiveBot/issues/109#issuecomment-313533407) that "we have lots of capacity and it's somewhat rare for anything to be in the queue". This is definitely not true anymore. Even though our capacity is now larger than ever before, we still end up with huge job queues more often than not. Before yesterday, we last had an empty queue two weeks ago (for just a few hours!), and there were over 20 jobs pending during most of October, with a peak of 50 mid-month. This means that urgent jobs often don't start for days unless you explicitly bypass the queue.

A few of the active people in `#archivebot` discussed this in the past two days, and this PR is the outcome of that discussion. Restricting the addition of new jobs to opped users when there is a non-negligible queue should cut down on at least some of the jobs in those huge queues by forcing voiced people to actually stay around and add jobs when there is space in the queue while still allowing ops to override this.