### PR TITLE
Add WPULL_MONITOR_DISK/MEMORY env vars

### DIFF
--- a/pipeline/archivebot/seesaw/wpull.py
+++ b/pipeline/archivebot/seesaw/wpull.py
@@ -9,7 +9,7 @@ def add_args(args, names, item):
         if value:
             args.append(value)
 
-def make_args(item, default_user_agent, wpull_exe, youtube_dl_exe, phantomjs_exe, finished_warcs_dir, warc_max_size):
+def make_args(item, default_user_agent, wpull_exe, youtube_dl_exe, phantomjs_exe, finished_warcs_dir, warc_max_size, monitor_disk, monitor_memory):
     # -----------------------------------------------------------------------
     # BASE ARGUMENTS
     # -----------------------------------------------------------------------
@@ -46,8 +46,8 @@ def make_args(item, default_user_agent, wpull_exe, youtube_dl_exe, phantomjs_exe
         '--strip-session-id',
         '--escaped-fragment',
         '--session-timeout', '21600',
-        '--monitor-disk', '500m',
-        '--monitor-memory', '50m',
+        '--monitor-disk', monitor_disk,
+        '--monitor-memory', monitor_memory,
         '--max-redirect', '8',
         '--youtube-dl-exe', youtube_dl_exe
     ]
@@ -109,17 +109,19 @@ def make_args(item, default_user_agent, wpull_exe, youtube_dl_exe, phantomjs_exe
 # ---------------------------------------------------------------------------
 
 class WpullArgs(object):
-    def __init__(self, *, default_user_agent, wpull_exe, youtube_dl_exe, phantomjs_exe, finished_warcs_dir, warc_max_size):
+    def __init__(self, *, default_user_agent, wpull_exe, youtube_dl_exe, phantomjs_exe, finished_warcs_dir, warc_max_size, monitor_disk, monitor_memory):
         self.default_user_agent = default_user_agent
         self.wpull_exe = wpull_exe
         self.youtube_dl_exe = youtube_dl_exe
         self.phantomjs_exe = phantomjs_exe
         self.finished_warcs_dir = finished_warcs_dir
         self.warc_max_size = warc_max_size
+        self.monitor_disk = monitor_disk
+        self.monitor_memory = monitor_memory
 
     def realize(self, item):
         return make_args(item, self.default_user_agent, self.wpull_exe,
             self.youtube_dl_exe, self.phantomjs_exe, self.finished_warcs_dir,
-            self.warc_max_size)
+            self.warc_max_size, self.monitor_disk, self.monitor_memory)
 
 # vim:ts=4:sw=4:et:tw=78

--- a/pipeline/archivebot/seesaw/wpullargs_test.py
+++ b/pipeline/archivebot/seesaw/wpullargs_test.py
@@ -9,6 +9,8 @@ if 'WARC_MAX_SIZE' in env:
     WARC_MAX_SIZE = env['WARC_MAX_SIZE']
 else:
     WARC_MAX_SIZE = '5368709120'
+WPULL_MONITOR_DISK = env.get('WPULL_MONITOR_DISK', '500m')
+WPULL_MONITOR_MEMORY = env.get('WPULL_MONITOR_MEMORY', '50m')
 
 def joined(args):
     return str.join(' ', args)
@@ -28,7 +30,9 @@ class TestWpullArgs(unittest.TestCase):
                 youtube_dl_exe='/usr/bin/youtube-dl',
                 phantomjs_exe='/usr/bin/phantomjs',
                 finished_warcs_dir='/lost+found/',
-                warc_max_size=WARC_MAX_SIZE
+                warc_max_size=WARC_MAX_SIZE,
+                monitor_disk=WPULL_MONITOR_DISK,
+                monitor_memory=WPULL_MONITOR_MEMORY,
             )
 
     def test_user_agent_can_be_set(self):

--- a/pipeline/pipeline.py
+++ b/pipeline/pipeline.py
@@ -30,7 +30,7 @@ from archivebot.seesaw.tasks import GetItemFromQueue, StartHeartbeat, \
     SetFetchDepth, PreparePaths, WriteInfo, DownloadUrlFile, \
     RelabelIfAborted, MoveFiles, StopHeartbeat, MarkItemAsDone, CheckIP
 
-VERSION = "20180922.01"
+VERSION = "20190427.01"
 PHANTOMJS_VERSIONS = ('1.9.8', '2.1.1')
 WPULL_VERSION = ('2.0.3')
 EXPIRE_TIME = 60 * 60 * 48  # 48 hours between archive requests

--- a/pipeline/pipeline.py
+++ b/pipeline/pipeline.py
@@ -62,6 +62,8 @@ if 'WARC_MAX_SIZE' in env:
     WARC_MAX_SIZE = env['WARC_MAX_SIZE']
 else:
     WARC_MAX_SIZE = '5368709120'
+WPULL_MONITOR_DISK = env.get('WPULL_MONITOR_DISK', '500m')
+WPULL_MONITOR_MEMORY = env.get('WPULL_MONITOR_MEMORY', '50m')
 
 assert 'TMUX' in env or 'STY' in env or env.get('NO_SCREEN') == "1", \
         "Refusing to start outside of screen or tmux, set NO_SCREEN=1 to override"
@@ -122,7 +124,9 @@ wpull_args = WpullArgs(
     youtube_dl_exe=YOUTUBE_DL,
     phantomjs_exe=PHANTOMJS,
     finished_warcs_dir=os.environ["FINISHED_WARCS_DIR"],
-    warc_max_size=WARC_MAX_SIZE
+    warc_max_size=WARC_MAX_SIZE,
+    monitor_disk=WPULL_MONITOR_DISK,
+    monitor_memory=WPULL_MONITOR_MEMORY,
 )
 
 pipeline = Pipeline(


### PR DESCRIPTION
The defaults might not fit every pipeline and are a bit low when it
comes to large file downloads. Make them configureable.

I don’t know how to run the test suite though.