### PR TITLE
Add alias --concurrent for !a/!ao command and !concurrent for !concurrency

### DIFF
--- a/bot/command_patterns.rb
+++ b/bot/command_patterns.rb
@@ -8,7 +8,7 @@ module CommandPatterns
   ARCHIVEONLY       = %r{\A(?:\!ao|\!archiveonly)(?!\s+<)\s+#{AC}\s*\Z}
   ARCHIVEONLY_FILE  = %r{\A(?:\!ao|\!archiveonly)\s+<\s+#{AC}\s*\Z}
   SET_DELAY         = %r{\A\!d(?:elay)?\s+(#{IDENT})\s+(#{DELAY_SPEC})\s+(#{DELAY_SPEC})\s*\Z}
-  SET_CONCURRENCY   = %r{\A\!con(?:currency)?\s+(#{IDENT})\s+(\d{1,2})\s*\Z}
+  SET_CONCURRENCY   = %r{\A\!con(?:curren(?:cy|t))?\s+(#{IDENT})\s+(\d{1,2})\s*\Z}
   IGNORE            = %r{\A!ig(?:nore)?\s+(#{IDENT})\s+([^\s]+)\s*\Z}
   UNIGNORE          = %r{\A!(?:ug|unig(?:nore)?)\s+(#{IDENT})\s+([^\s]+)\s*\Z}
   WHEREIS           = %r{\A!w(?:hereis)?\s+(#{IDENT})\s*\Z}

--- a/bot/job_options_parser.rb
+++ b/bot/job_options_parser.rb
@@ -28,6 +28,7 @@ class JobOptionsParser
                when '--ignoresets','--ignore_sets','--ignoreset','--ignore-set','--ignore_set','--ig-set','--igset' then '--ignore-sets'
                when '--nooffsitelinks','--no-offsite','--nooffsite' then '--no-offsite-links'
                when '--useragentalias','--user-agent','--useragent' then '--user-agent-alias'
+               when '--concurrent' then '--concurrency'
                else b[0]
                end)
         b.join('=')

--- a/doc/commands.rst
+++ b/doc/commands.rst
@@ -447,7 +447,7 @@ milliseconds.  The default inter-request delay range is [250, 375] ms.
 concurrency
 ===========
 
-``!concurrency IDENT LEVEL``, ``!con IDENT LEVEL``
+``!concurrency IDENT LEVEL``, ``!concurrent IDENT LEVEL``, ``!con IDENT LEVEL``
     set concurrency level::
 
        > !concurrency 1q2qydhkeh3gfnrcxuf6py70b 8

--- a/doc/commands.rst
+++ b/doc/commands.rst
@@ -138,6 +138,8 @@ Accepted parameters
     alias for ``!concurrency``
     sets number of workers for job (use with care!)
 
+    Alias: ``--concurrent``
+
 ``--large``
     Job includes many large (>500MB) files. Job will be sent to
     pipelines that define the `LARGE` environment.


### PR DESCRIPTION
wpull's option is called --concurrent, so it makes sense to support that on ArchiveBot as well.

I often get confused by that discrepancy, and according to my logs, I'm not the only one who accidentally used --concurrent instead of --concurrency in the past.