### PR TITLE
Update Safari UA

### DIFF
--- a/db/user_agents/safari.json
+++ b/db/user_agents/safari.json
@@ -6,7 +6,7 @@
                 "safari-mac",
                 "safari-osx"
             ],
-            "name": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_1) AppleWebKit/601.2.7 (KHTML, like Gecko) Version/9.0.1 Safari/601.2.7"
+            "name": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1 Safari/605.1.15"
         },
         {
             "aliases": [


### PR DESCRIPTION
Updated Safari UA for Mac OSX with the string for High Sierra