### PR TITLE
Ignore Squarespace JS hell

### DIFF
--- a/db/ignore_patterns/global.json
+++ b/db/ignore_patterns/global.json
@@ -202,7 +202,8 @@
         "http://connect\\.qq\\.com/widget/shareqq/index\\.html\\?",
         "^https?://web\\.whatsapp\\.com/send\\?",
         "^https?://(direct\\.(france(info|inter|culture|musique|bleu)|fipradio|mouv)\\.fr|[^/.]+\\.cdn\\.dvmr\\.fr(:\\d+)?)/.*\\.mp3$",
-        "^https?://www\\.testtesttest\\.com/"
+        "^https?://www\\.testtesttest\\.com/",
+        "^https?://static\\.squarespace\\.com/universal/scripts-compressed/src/main/webapp/universal/"
     ],
     "type": "ignore_patterns"
 }


### PR DESCRIPTION
Not sure when this started, but lately we had a lot of jobs retrieve thousands of inexistent URLs from Squarespace due to wpull's JS extraction. The actual scripts are in .../scripts-compressed/; I haven't found any valid URLs in deeper directories.