### PR TITLE
Add igsets for GitHub

### DIFF
--- a/db/ignore_patterns/github.json
+++ b/db/ignore_patterns/github.json
@@ -1,0 +1,20 @@
+{
+	"name": "github",
+	"patterns": [
+		"^https?://github\\.com/[^/]+/[^/]+/(search|find|blame|diffs|compare|notifications)[/?]",
+		"^https?://github\\.com/.*/(s,|,Meta\\+|Control\\+)/",
+		"^https?://github\\.com/[^/]+/[^/]+/(issues|pulls)(/show_menu_content)?\\?(.*&)?q=(.*\\+)?-?(label|sort|assignee|author|project|milestone|review|no|updated|comments|base)(%3A|:)",
+		"^https?://github\\.com/[^/]+/[^/]+/projects\\?query=([^&]+\\+)?sort(%3A|:)",
+		"^https?://github\\.com/[^/]+/[^/]+/milestones\\?(.*&)?(sort|direction)=",
+		"^https?://github\\.com/[^/]+/[^/]+/(issues/)?labels\\?(.*&)?sort=",
+		"^https?://github\\.com/[^/]+/[^/]+/(issues|pull)/new[/?]",
+		"^https?://github\\.com/[^/]+/[^/]+/commits/[0-9a-f]{40}([/?]|$)",
+		"^https?://github\\.com/[^/]+/[^/]+/commit/[0-9a-f]{40}\\?diff=",
+		"^https?://github\\.com/[^/]+/[^/]+/issues/\\d+/set_milestone\\?",
+		"^https?://github\\.com/[^/]+/[^/]+/pull/\\d+/review-requests\\?",
+		"^https?://github\\.com/[^/]+/[^/]+/projects/issues/\\d+$",
+		"^https?://github\\.com/[^/]+/[^/]+/pull/\\d+/(?!commits/).*/",
+		"^https?://github\\.com/[^/]+/[^/]+/(tree|blob|raw)/[0-9a-f]{40}/"
+	],
+	"type": "ignore_patterns"
+}

--- a/db/ignore_patterns/nogithubcode.json
+++ b/db/ignore_patterns/nogithubcode.json
@@ -1,0 +1,7 @@
+{
+	"name": "nogithubcode",
+	"patterns": [
+		"^https?://github\\.com/[^/]+/[^/]+/(tree(-commit)?|blob(_excerpt)?|raw|commits?|branch_commits|file-list)([/?]|$)"
+	],
+	"type": "ignore_patterns"
+}


### PR DESCRIPTION
"github" is the general igset that should be used with GitHub grabs. "nogithubcode" ignores the code itself and should probably be used for any repository that isn't just a few commits and files large.

Explanations for the github ignores:
- search, find, blame, diffs, compare, and notifications are obvious redundant views or other unnecessary things.
- s, etc. are somehow related to keyboard shortcuts (wpull's JS extraction) and cause infinite loops.
- q=(.*\\+)?-?(label... ignores redundant views of issues and PRs (filtered by labels, milestones, author, etc.)
- The next three ignores handle sorting. I couldn't verify that projects, labels, and milestones will work correctly in the case of pagination because I couldn't find any repository with enough of those things to have pagination in the first place.
- We don't need login pages, so no "new issue/PR" either.
- /commits/: The intent here is to ignore the commit history in the repository starting from each commit (and worse, from each file as well). It will still grab the history starting from each branch or tag, both for the entire branch/tag and from each file. All of these ignored URLs should be redundant save for file contents which aren't included in the general commit page due to size; however, since we always grab the archives for each commit anyway (unless 'nogithubcode' is also used), that's not actually an issue. Doing it properly, i.e. fake-clicking the "Load diff" thing on large commits for each file, would require custom code.
- /commit/ diff=: Redundant diff view
- set_milestone, review-requests, and /projects/issues/ are POST form targets.
- /pull/\d+/(?!commits/): The problem here is that there's a 'path/file.ext' somewhere in the HTML for each file that was modified in the PR. wpull will think that this is a path and try to retrieve it. The proper solution would be something similar to what we do (if it worked) for Drupal, but that's a lot more work...
- tree|blob|raw: This lets it grab the entire repository for each branch and tag, but not for each commit. Note the trailing slash; the repository root *will* get grabbed for each commit, and as such, the archive zip link for each commit will be discovered and grabbed as well (without nogithubcode). In other words, we do grab a snapshot of the entire repository for each commit.