### PR TITLE
Ignore reverse pagination on custom Blogspot domains as well

### DIFF
--- a/db/ignore_patterns/blogs.json
+++ b/db/ignore_patterns/blogs.json
@@ -12,7 +12,7 @@
         "'\\%20\\+\\%20liker\\.(avatar|profile)_URL\\%20\\+\\%20'",
         "\\%22\\%20\\+\\%20$wrapper\\.data\\(",
         "^https?://.+\\.blogspot\\.(com|in|com\\.au|co\\.uk|jp|co\\.nz|ca|de|it|fr|se|sg|es|pt|com\\.br|ar|mx|kr)/\\d{4,4}/\\d{2,2}/CSI/$",
-        "^https?://.+\\.blogspot\\.(com|in|com\\.au|co\\.uk|jp|co\\.nz|ca|de|it|fr|se|sg|es|pt|com\\.br|ar|mx|kr)/search\\?(.*&)?reverse-paginate=true(&|$)",
+        "^https?://[^/]+/search\\?(.*&)?reverse-paginate=true(&|$)",
         "livejournal\\.com/ljcounter/?\\?",
         "\\?replyto=[0-9]+",
         "[\\?&]mode=reply",


### PR DESCRIPTION
The ignore is specific enough that there shouldn't be any relevant false positives.