### PR TITLE
Reduce spam by only sending one message when a job is queued

### DIFF
--- a/bot/brain.rb
+++ b/bot/brain.rb
@@ -127,7 +127,7 @@ class Brain
       if depth == :shallow
         reply m, "Queued #{urls_in}#{uri.to_s} for archival without recursion. (job ID: #{job.ident} )"
       else
-        reply m, "Queued #{urls_in}#{uri.to_s}. (job ID: #{job.ident})"
+        reply m, "Queued #{urls_in}#{uri.to_s}. (job ID: #{job.ident} )"
       end
 
       if user_agent

--- a/bot/brain.rb
+++ b/bot/brain.rb
@@ -125,16 +125,14 @@ class Brain
       urls_in = 'URLs in ' if url_file
 
       if depth == :shallow
-        reply m, "Queued #{urls_in}#{uri.to_s} for archival without recursion."
+        reply m, "Queued #{urls_in}#{uri.to_s} for archival without recursion. (job ID: #{job.ident} )"
       else
-        reply m, "Queued #{urls_in}#{uri.to_s}."
+        reply m, "Queued #{urls_in}#{uri.to_s}. (job ID: #{job.ident})"
       end
 
       if user_agent
         reply m, "Using user-agent #{user_agent}."
       end
-
-      reply m, "Use !status #{job.ident} for updates, !abort #{job.ident} to abort."
 
       if h[:explain]
         add_note(m, job, h[:explain], false)


### PR DESCRIPTION
When a job is queued, include the job ID in the "Queued URL's" message, instead of posting in a separate message.