### PR TITLE
Ignore WordPress Fastest Cache's minified JS recursion

### DIFF
--- a/db/ignore_patterns/blogs.json
+++ b/db/ignore_patterns/blogs.json
@@ -32,7 +32,8 @@
         "^https?://www\\.dreamwidth\\.org/tools/(memadd|tellafriend)\\?",
         "^https?://[^\\.]+\\.dreamwidth\\.org/.+[\\?&]mode=reply",
         "[?&]SuperSocializerAuth=(LiveJournal|Twitch|Twitter|Xing)(&|$)",
-        "^https?://wordpress\\.com/log-in\\?"
+        "^https?://wordpress\\.com/log-in\\?",
+        "/wp-content/cache/wpfc-minified/[^/]+/[^/]+/"
     ],
     "type": "ignore_patterns"
 }


### PR DESCRIPTION
The WordPress plugin [Fastest Cache](https://wordpress.org/plugins/wp-fastest-cache/) minifies JS and CSS, and wpull's naive JS URL extraction leads to deep recursion due to this. URLs of the minified JS/CSS are of the form `/wp-cache/cache/wpfc-minified/randomchars/file.ext` (where randomchars is some sort of hash over the file contents); there are no directories inside that path, and Fastest Cache always serves the same file based on only the hash (wpFastestCache.php lines 247 ff. in version 0.8.9.3).