### PR TITLE
Block uploading to an rsync URL that doesn't end in a slash

### DIFF
--- a/uploader/uploader.py
+++ b/uploader/uploader.py
@@ -40,6 +40,11 @@ class Params:
                 raise RuntimeError('Won\'t let you upload to localhost because I '
                                    'remove files after uploading them, and you '
                                    'might be uploading to the same directory')
+            if not str(self.url).endswith('/'):
+                print(str(self.url))
+                raise RuntimeError('Won\'t let you run without a trailing slash on '
+                               'rsync directory')
+
             self.mode = 'rsync'
 
         if self.url is None:


### PR DESCRIPTION
https://github.com/ArchiveTeam/ArchiveBot/issues/305

Fixes issue 305.