### PR TITLE
Ignore a CBL sinkhole domain

### DIFF
--- a/db/ignore_patterns/global.json
+++ b/db/ignore_patterns/global.json
@@ -203,6 +203,7 @@
         "^https?://((web|api)\\.whatsapp\\.com/send|wa\\.me/)\\?",
         "^https?://(direct\\.(france(info|inter|culture|musique|bleu)|fipradio|mouv)\\.fr|[^/.]+\\.cdn\\.dvmr\\.fr(:\\d+)?)/.*\\.mp3$",
         "^https?://www\\.testtesttest\\.com/",
+        "^https?://(www\\.cgzxb\\.com|216\\.218\\.185\\.162)/",
         "^https?://static\\.squarespace\\.com/universal/scripts-compressed/src/main/webapp/universal/",
         "^https?://www\\.facebook\\.com/dialog/send\\?",
         "^https?://linkedin\\.com/shareArticle\\?",


### PR DESCRIPTION
`www<dot>cgzxb<dot>com` is associated with some malware, and accessing it causes a listing on the CBL.