### PR TITLE
Update tests (August 2019)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,11 @@ install:
   - bundle install --jobs=3 --retry=3 --deployment
   - cd plumbing && bundle install --jobs=3 --retry=3 --deployment && cd ..
   - sudo apt-get -qq install ircd-hybrid $PYTHON $PYTHON-dev rsync libzmq3-dev
-  - sudo $PYTHON get-pip.py
-  - travis_retry $PYTHON -m pip install -q -r pipeline/requirements.txt --user
-  - travis_retry $PYTHON -m pip install -q nose pytest irc --user
+  - /usr/bin/$PYTHON get-pip.py --user
+  - travis_retry /usr/bin/$PYTHON -m pip install -q -r pipeline/requirements.txt --user
+  - travis_retry /usr/bin/$PYTHON -m pip install -q nose pytest irc --user
   - sudo cp test/example_rsyncd.conf /etc/rsyncd.conf
-  - $PYTHON -m pip install -q git+https://github.com/chfoo/huhhttp#egg=huhhttp --user
+  - /usr/bin/$PYTHON -m pip install -q git+https://github.com/chfoo/huhhttp#egg=huhhttp --user
 
 before_script:
   - curl -X PUT http://127.0.0.1:5984/archivebot
@@ -59,6 +59,6 @@ services:
 
 script:
   - bundle exec rake
-  - $PYTHON -m nose pipeline/
-  - $PYTHON -m pytest test/validate_db.py
-  - $PYTHON test/integration_runner.py
+  - /usr/bin/$PYTHON -m nose pipeline/
+  - /usr/bin/$PYTHON -m pytest test/validate_db.py
+  - /usr/bin/$PYTHON test/integration_runner.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ rvm:
   - 2.2.3
 
 env:
-- PYTHON=python3.4
+  - PYTHON=python3.5
+  - PYTHON=python3.6
 
 #notifications:
 #  irc:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
 #    - "irc.efnet.net#archivebot"
 
 before_install:
-  - sudo add-apt-repository ppa:fkrull/deadsnakes --yes
+  - sudo add-apt-repository ppa:deadsnakes/ppa --yes
   - sudo apt-get update -qq
   - wget https://bootstrap.pypa.io/get-pip.py
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,10 @@ install:
   - cd plumbing && bundle install --jobs=3 --retry=3 --deployment && cd ..
   - sudo apt-get -qq install ircd-hybrid $PYTHON $PYTHON-dev rsync libzmq3-dev
   - /usr/bin/$PYTHON get-pip.py --user
-  - travis_retry /usr/bin/$PYTHON -m pip install -q -r pipeline/requirements.txt --user
-  - travis_retry /usr/bin/$PYTHON -m pip install -q nose pytest irc --user
+  - travis_retry /usr/bin/$PYTHON -m pip install -r pipeline/requirements.txt --user
+  - travis_retry /usr/bin/$PYTHON -m pip install nose pytest irc --user
   - sudo cp test/example_rsyncd.conf /etc/rsyncd.conf
-  - /usr/bin/$PYTHON -m pip install -q git+https://github.com/chfoo/huhhttp#egg=huhhttp --user
+  - /usr/bin/$PYTHON -m pip install git+https://github.com/chfoo/huhhttp#egg=huhhttp --user
 
 before_script:
   - curl -X PUT http://127.0.0.1:5984/archivebot

--- a/db/ignore_patterns/meetupeverywhere.json
+++ b/db/ignore_patterns/meetupeverywhere.json
@@ -1,7 +1,7 @@
 {
     "name": "meetupeverywhere",
     "patterns": [
-        "^https?://.*\\meetup\\.com/login/"
+        "^https?://([^/]+\\.)?meetup\\.com/login/"
     ],
     "type": "ignore_patterns"
 }

--- a/test/run_pipeline.sh
+++ b/test/run_pipeline.sh
@@ -11,7 +11,7 @@ mkdir -p /tmp/warc/
 
 # This will affect the wpull exe wrapper
 mkdir -p /tmp/bin/
-ln -s /usr/bin/python3.4 /tmp/bin/python3
+ln -s /usr/bin/$PYTHON /tmp/bin/python3
 
 echo -n 'Using '
 which python3


### PR DESCRIPTION
* Bump Python version and run tests on both 3.5 and 3.6. Python 3.4 is unsupported, not used by any current pipeline (to my knowledge), and can no longer run lxml since a few weeks ago (version 4.4.0).
* Fix a broken ignore pattern in the meetupeverywhere igset
* Replace outdated deadsnakes PPA that hasn't been updated since 2017
* Work around https://github.com/pyenv/pyenv/issues/789 by directly running `/usr/bin/python3.6`
* Remove quiet flags on pip installs so we can see what's going on there