### PR TITLE
Notify IRC channel on pipeline changes

### DIFF
--- a/bot/bot.rb
+++ b/bot/bot.rb
@@ -6,6 +6,7 @@ require 'uri'
 require File.expand_path('../brain', __FILE__)
 require File.expand_path('../command_patterns', __FILE__)
 require File.expand_path('../finish_notifier', __FILE__)
+require File.expand_path('../pipeline_notifier', __FILE__)
 require File.expand_path('../../lib/couchdb', __FILE__)
 
 opts = Trollop.options do
@@ -36,10 +37,11 @@ bot = Cinch::Bot.new do
     c.nick = opts[:nick]
     c.channels = channels
     c.password = opts[:password]
-    c.plugins.plugins = [FinishNotifier]
+    c.plugins.plugins = [FinishNotifier, PipelineNotifier]
     c.plugins.options[FinishNotifier] = {
       redis: redis
     }
+    c.plugins.options[PipelineNotifier] = {redis: redis}
 
     if uri.scheme == 'ircs'
       c.ssl.use = true

--- a/bot/pipeline_notifier.rb
+++ b/bot/pipeline_notifier.rb
@@ -1,0 +1,37 @@
+require 'cinch'
+
+require File.expand_path('../../lib/pipeline_collection', __FILE__)
+
+class PipelineNotifier
+  include Cinch::Plugin
+
+  CYCLE = 30  # seconds
+
+  timer CYCLE, method: :announce_pipeline_changes
+
+  def initialize(*args)
+    super
+    @known_pipelines = []
+  end
+
+  def announce_pipeline_changes
+    current_pipelines = PipelineCollection.new(config[:redis]).map {|x| x.select {|key, value| ["id", "nickname", "version"].include?(key)} }
+
+    vanished_pipelines = @known_pipelines - current_pipelines
+    new_pipelines = current_pipelines - @known_pipelines
+
+    vanished_pipelines.each do |pipeline|
+      bot.channels.each do |channel|
+        channel.send(%Q{Pipeline "#{pipeline['nickname']}" (#{pipeline['id']}) disconnected.})
+      end
+    end
+
+    new_pipelines.each do |pipeline|
+      bot.channels.each do |channel|
+        channel.send(%Q{Pipeline "#{pipeline['nickname']}" (#{pipeline['id']}, version #{pipeline['version']}) connected.})
+      end
+    end
+
+    @known_pipelines = current_pipelines
+  end
+end

--- a/dashboard/resources/pipeline.rb
+++ b/dashboard/resources/pipeline.rb
@@ -1,5 +1,7 @@
 require 'webmachine'
 
+require File.expand_path('../../../lib/pipeline_collection', __FILE__)
+
 class Pipeline < Webmachine::Resource
   class << self
     attr_accessor :redis
@@ -18,38 +20,5 @@ class Pipeline < Webmachine::Resource
 
   def to_html
     File.read(File.expand_path('../../pipeline.html', __FILE__))
-  end
-end
-
-##
-# SCANs for pipeline keys.  When it finds one it hasn't yet seen, performs an
-# HGETALL on that key and yields the resulting hash.
-class PipelineCollection
-  include Enumerable
-
-  attr_reader :redis
-
-  def initialize(redis)
-   @redis = redis
-  end
-
-  def each
-    return to_enum unless block_given?
-
-    cursor = 0
-    seen = {}
-
-    loop do
-      cursor, keys = redis.scan(cursor, match: 'pipeline:*')
-
-      keys.each do |k|
-        next if seen[k]
-
-        seen[k] = true
-        yield redis.hgetall(k)
-      end
-
-      break if cursor.to_i == 0
-    end
   end
 end

--- a/lib/pipeline_collection.rb
+++ b/lib/pipeline_collection.rb
@@ -1,0 +1,32 @@
+##
+# SCANs for pipeline keys.  When it finds one it hasn't yet seen, performs an
+# HGETALL on that key and yields the resulting hash.
+class PipelineCollection
+  include Enumerable
+
+  attr_reader :redis
+
+  def initialize(redis)
+   @redis = redis
+  end
+
+  def each
+    return to_enum unless block_given?
+
+    cursor = 0
+    seen = {}
+
+    loop do
+      cursor, keys = redis.scan(cursor, match: 'pipeline:*')
+
+      keys.each do |k|
+        next if seen[k]
+
+        seen[k] = true
+        yield redis.hgetall(k)
+      end
+
+      break if cursor.to_i == 0
+    end
+  end
+end


### PR DESCRIPTION
Fixes #332

Unfortunately, due to the simple implementation (no real memory, only inside the bot), the entire list of pipelines is announced to the channel when the IRC bot starts up. In other words, there'll be some spam after bot reboots. But I consider that the lesser evil compared to not being able to tell what pipeline an ID corresponds to down the line, and it can be fixed in the future if it becomes a problem. Fortunately, we don't need to restart the bot very often.