### PR TITLE
Require that the time zone is set to UTC on pipelines

### DIFF
--- a/pipeline/pipeline.py
+++ b/pipeline/pipeline.py
@@ -1,4 +1,5 @@
 import atexit
+import datetime
 from distutils.version import StrictVersion
 from os import environ as env
 import os
@@ -72,6 +73,8 @@ if StrictVersion(seesaw.__version__) < StrictVersion("0.1.8b1"):
     )
 
 assert downloader not in ('ignorednick', 'YOURNICKHERE'), 'please use a real nickname'
+
+assert datetime.datetime.now(datetime.timezone.utc).astimezone().tzinfo.utcoffset(None).seconds == 0, 'Please set the time zone to UTC'
 
 RSYNC_URL = env['RSYNC_URL']
 REDIS_URL = env['REDIS_URL']


### PR DESCRIPTION
While the WARC files record the UTC date, log timestamps and filenames use the local timezone (but without any TZ indication). This discrepancy can be confusing and is completely unnecessary.

Pipeline operators, if you really must keep the time zone on your systems at some offset which is ambiguous once per year (DST), `export TZ=UTC` before running the pipeline.