### PR TITLE
Add basic Instagram igset

### DIFF
--- a/db/ignore_patterns/instagram.json
+++ b/db/ignore_patterns/instagram.json
@@ -1,0 +1,8 @@
+{
+	"name": "instagram",
+	"patterns": [
+		"^https?://www\\.instagram\\.com/.*[?&]hl=",
+		"^https?://www\\.instagram\\.com/p/[^/]+/caption/[^/]+/.+/"
+	],
+	"type": "ignore_patterns"
+}


### PR DESCRIPTION
`?hl=` is the language switcher. Captions started appearing in URLs in early August; legitimate canonical post URLs are `/p/CODE/caption/SLUG` (i.e. no slash at the end).