### PR TITLE
Ignore "BlogArchive" widget on Blogger

### DIFF
--- a/db/ignore_patterns/blogs.json
+++ b/db/ignore_patterns/blogs.json
@@ -13,6 +13,7 @@
         "\\%22\\%20\\+\\%20$wrapper\\.data\\(",
         "^https?://.+\\.blogspot\\.(com|in|com\\.au|co\\.uk|jp|co\\.nz|ca|de|it|fr|se|sg|es|pt|com\\.br|ar|mx|kr)/\\d{4,4}/\\d{2,2}/CSI/$",
         "^https?://[^/]+/search\\?(.*&)?reverse-paginate=true(&|$)",
+        "^https?://[^/]+\\.blogspot\\.(com|in|com\\.au|co\\.uk|jp|co\\.nz|ca|de|it|fr|se|sg|es|pt|com\\.br|ar|mx|kr)/(?!\\?widgetType=BlogArchive&).*[?&]toggle(open)?=(WEEKLY|MONTHLY|YEARLY)-\\d+(&|$)",
         "livejournal\\.com/ljcounter/?\\?",
         "\\?replyto=[0-9]+",
         "[\\?&]mode=reply",


### PR DESCRIPTION
The widget generates URLs for toggling the monthly or weekly archives in the sidebar.

This still lets it grab the entire tree on the homepage. The problem is when it starts doing that on every single page of the blog.