### PR TITLE
Support weaker SSL/TLS connections for a broader compatibility with outdated web servers

### DIFF
--- a/INSTALL.pipeline
+++ b/INSTALL.pipeline
@@ -77,6 +77,12 @@ As user archivebot, in the SECOND tmux session:
     export REDIS_URL=redis://127.0.0.1:16379/0
     export FINISHED_WARCS_DIR=$HOME/warcs4fos
 
+If you run the pipeline on a system with a modern OpenSSL version
+(e.g. Debian Buster and later), which comes with a more secure default
+configuration, additionally set the OPENSSL_CONF environment variable:
+
+    export OPENSSL_CONF=/home/archivebot/ArchiveBot/ops/openssl-less-secure.cnf
+
 Now, think up a name for this new ArchiveBot pipeline.  It will 
 appear on the publicly available pipeline status dashboard. It will 
 go in the command you enter next:

--- a/ops/openssl-less-secure.cnf
+++ b/ops/openssl-less-secure.cnf
@@ -1,0 +1,2 @@
+MinProtocol = None
+CipherString = DEFAULT

--- a/pipeline/archivebot/seesaw/wpull.py
+++ b/pipeline/archivebot/seesaw/wpull.py
@@ -24,6 +24,7 @@ def make_args(item, default_user_agent, wpull_exe, youtube_dl_exe, finished_warc
         '--html-parser', 'libxml2-lxml',
         '--save-cookies', '%(cookie_jar)s' % item,
         '--no-check-certificate',
+        '--no-strong-crypto',
         '--delete-after',
         '--no-robots',
         '--page-requisites',


### PR DESCRIPTION
wpull's `--no-strong-crypto` allows for SSLv2 and SSLv3 connections (if the OpenSSL library is built accordingly) and compression.
The OpenSSL configuration file overrides the defaults that are shipped e.g. with Debian Buster, which only accept TLSv1.2+ and decently secure cipher suites.

Fixes #424 (hopefully)