### PR TITLE
Include CentralAuth to mediawiki ignore rule

### DIFF
--- a/db/ignore_patterns/mediawiki.json
+++ b/db/ignore_patterns/mediawiki.json
@@ -26,7 +26,7 @@
         "[\\?&]undo(after)?=\\d+",
         "^https?://a\\.wikia-beacon\\.com/__track/",
         "^https?://beacon\\.wikia-services\\.com/__track/",
-        "([\\?&]title=|/)Special:(PrefixIndex|WhatLinksHere|Contributions|ListFiles|ListUsers)/.*/\\2/",
+        "([\\?&]title=|/)Special:(PrefixIndex|WhatLinksHere|Contributions|ListFiles|ListUsers|CentralAuth)/.*/\\2/",
         "/User_talk:.+/User_talk:",
         "/User_blog:.+/User_blog:",
         "/User:.+/User:"


### PR DESCRIPTION
On wikimedia wikis, CentralAuth is the pandora's box responsible for crazy amount of other WMF-wiki userpages. See mine [1] for example - it has 775*3 links[2] to WMF-sisterprojects as of 2019-12-26, and it only increases when the new wiki is added to WMF farm. Therefore it is sensible to remove them from the archive target.

[1]: https://w.wiki/EUG
[2]: Link to user page (domain itself), block log, and contribution link.