### PR TITLE
Ignore pages on Gamepedia wikis that include things from the whole network

### DIFF
--- a/db/ignore_patterns/mediawiki.json
+++ b/db/ignore_patterns/mediawiki.json
@@ -29,7 +29,8 @@
         "([\\?&]title=|/)Special:(PrefixIndex|WhatLinksHere|Contributions|ListFiles|ListUsers|CentralAuth)/.*/\\2/",
         "/User_talk:.+/User_talk:",
         "/User_blog:.+/User_blog:",
-        "/User:.+/User:"
+        "/User:.+/User:",
+        "^https?://[^/]+\\.gamepedia\\.com/(.*[?&]title=)?Special:(WikiPoints/global|ListAllUsers|AllSites)([/?&]|$)"
     ],
     "type": "ignore_patterns"
 }


### PR DESCRIPTION
* Special:WikiPoints/global lists all users that have ever made an edit on any wiki in the network. The links to the users' profiles are all within the targeted wiki, so this blows up to millions and millions of URLs.
* Special:ListAllUsers is worse yet, listing all users registered on the network.
* Special:AllSites links to all wikis in the network.