### PR TITLE
Ignore various unnecessary or broken URLs on GitHub

### DIFF
--- a/db/ignore_patterns/github.json
+++ b/db/ignore_patterns/github.json
@@ -6,7 +6,7 @@
 		"^https?://github\\.com/[^/]+/[^/]+/(issues|pulls)(/show_menu_content)?\\?(.*&)?q=(.*\\+)?-?(label|sort|assignee|author|project|milestone|review|no|updated|comments|base)(%3A|:)",
 		"^https?://github\\.com/[^/]+/[^/]+/projects\\?query=([^&]+\\+)?sort(%3A|:)",
 		"^https?://github\\.com/[^/]+/[^/]+/milestones\\?(.*&)?(sort|direction)=",
-		"^https?://github\\.com/[^/]+/[^/]+/(issues/)?labels\\?(.*&)?sort=",
+		"^https?://github\\.com/[^/]+/[^/]+/(issues/)?labels/?\\?(.*&)?sort=",
 		"^https?://github\\.com/[^/]+/[^/]+/(issues|pull)/new[/?]",
 		"^https?://github\\.com/[^/]+/[^/]+/commits/[0-9a-f]{40}([/?]|$)",
 		"^https?://github\\.com/[^/]+/[^/]+/commit/[0-9a-f]{40}\\?diff=",
@@ -15,7 +15,13 @@
 		"^https?://github\\.com/[^/]+/[^/]+/projects/issues/\\d+$",
 		"^https?://github\\.com/[^/]+/[^/]+/pull/\\d+/(?!commits/).*/",
 		"^https?://github\\.com/[^/]+/[^/]+/(tree|blob|raw)/[0-9a-f]{40}/",
-		"^https?://github\\.com/[^/]+/[^/]+/actions(/.*)?\\?(.*&)?query=[^&]+\\+"
+		"^https?://github\\.com/[^/]+/[^/]+/actions(/.*)?\\?(.*&)?query=[^&]+\\+",
+		"^https?://github\\.com/[^/]+/[^/]+/runs/\\d+/(header$|toolbar(\\?|$)|step_summary\\?|unseen_check_steps\\?)",
+		"^https?://github\\.com/[^/]+/[^/]+/suites/\\d+/show_partial\\?",
+		"^https?://github\\.com/[^/]+/[^/]+/actions/runs/\\d+/workflow_run$",
+		"^https?://github\\.com/[^/]+/[^/]+/(issues|pull)/[^/]+/hovercard$",
+		"^https?://github\\.com/[^/]+/[^/]+/packages\\?(.*&)?sort_by=",
+		"^https?://github\\.com/.*/(Sortable|randomColor|drag-drop|gist-vendor)\\.js$"
 	],
 	"type": "ignore_patterns"
 }


### PR DESCRIPTION
* First three additions are 404s (data-url, possible available with special headers or something).
* hovercard is 406.
* Package sorting.
* Scripts picked up by wpull's JS string extraction (might have some false positives but should be very rare).