### PR TITLE
Fix webmachine-sprockets dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ group :dashboard do
   gem 'json'
   gem 'reel'
   gem 'webmachine', :git => 'https://github.com/seancribbs/webmachine-ruby.git'
-  gem 'webmachine-sprockets', :git => 'https://github.com/lgierth/webmachine-sprockets.git'
+  gem 'webmachine-sprockets', :git => 'https://github.com/ArchiveTeam/webmachine-sprockets.git'
   gem 'erubis'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: https://github.com/lgierth/webmachine-sprockets.git
+  remote: https://github.com/ArchiveTeam/webmachine-sprockets.git
   revision: cf8c0d4e0c2383f39f4c68eff9979ccc4a7f7fe9
   specs:
     webmachine-sprockets (0.2.0)


### PR DESCRIPTION
https://github.com/lgierth/webmachine-sprockets was deleted or made private sometime between 2020-05-08 (https://web.archive.org/web/20200508141612/https://github.com/lgierth) and 2020-06-25 (#452). This breaks tests and new installations.

Replacing it with our own fork of the only copy remaining on GitHub