### PR TITLE
Ignore Littlstar video files

### DIFF
--- a/db/ignore_patterns/global.json
+++ b/db/ignore_patterns/global.json
@@ -207,7 +207,8 @@
         "^https?://assets\\.squarespace\\.com/universal/scripts-compressed/src/main/webapp/universal/",
         "^https?://www\\.facebook\\.com/dialog/send\\?",
         "^https?://linkedin\\.com/shareArticle\\?",
-        "^https?://(line\\.me/R/msg/text/|lineit\\.line\\.me/share/ui|social-plugins\\.line\\.me/lineit/share)\\?"
+        "^https?://(line\\.me/R/msg/text/|lineit\\.line\\.me/share/ui|social-plugins\\.line\\.me/lineit/share)\\?",
+        "^https?://((videos|360)\\.littlstar\\.com|ls-video-masters\\.s3-accelerate\\.amazonaws\\.com)/.*\\.(mp4|mov|mkv|webm|avi|yuv|y4m)$"
     ],
     "type": "ignore_patterns"
 }


### PR DESCRIPTION
Some of these files are gigantic, especially the ones in the S3 bucket (4K VR etc., the largest file is 620 GB as of right now), and they've caused a number of crashes recently due to filling disks.

This ignore would not cover the video files that are actually used on the site or in the embed when accessed with a browser. For example, https://littlstar.com/videos/633a96a1 and https://embed.littlstar.com/videos/633a96a1 play back video files https://littlstar.com/embed/proxy/videos/3186eccb-e9d2-4735-bc41-c71a3e2b29cb/web.mp4 and https://embed.littlstar.com/proxy/videos/3186eccb-e9d2-4735-bc41-c71a3e2b29cb/web.mp4, respectively. These are not currently extracted by wpull though.