### PR TITLE
Adjust IRC rate limits

### DIFF
--- a/bot/bot.rb
+++ b/bot/bot.rb
@@ -49,6 +49,9 @@ bot = Cinch::Bot.new do
       c.ssl.use = true
       c.ssl.verify = true
     end
+
+    c.server_queue_size = 7
+    c.messages_per_second = 1.0
   end
 
   couchdb = Couchdb.new(URI(opts[:db]), opts[:db_credentials])


### PR DESCRIPTION
Cinch's standard limits of 10 queue size and 0.5 per second are a bit odd. 1 per second is generally acceptable on most networks, but at least on hackint, a slightly lower queue size seems to be necessary to avoid messages getting swallowed by *something*.