### PR TITLE
Pipeline preflight test improvements

### DIFF
--- a/pipeline/archivebot/seesaw/preflight.py
+++ b/pipeline/archivebot/seesaw/preflight.py
@@ -15,8 +15,8 @@ def check_wpull_args(wpull_args):
     print('Doing preflight check ', end='')
     sys.stdout.flush()
 
-    temp_dir = tempfile.TemporaryDirectory()
-    temp_log = tempfile.NamedTemporaryFile()
+    temp_dir = tempfile.TemporaryDirectory(prefix = 'tmp-wpull-preflight-', dir = '.')
+    temp_log = tempfile.NamedTemporaryFile(prefix = 'tmp-wpull-preflight-', suffix = '.log', dir = '.')
 
     item = MockItem({
         'url': 'http://archiveteam-invalid.com/',

--- a/pipeline/archivebot/seesaw/preflight.py
+++ b/pipeline/archivebot/seesaw/preflight.py
@@ -19,7 +19,7 @@ def check_wpull_args(wpull_args):
     temp_log = tempfile.NamedTemporaryFile(prefix = 'tmp-wpull-preflight-', suffix = '.log', dir = '.')
 
     item = MockItem({
-        'url': 'http://archiveteam-invalid.com/',
+        'url': 'http://archiveteam.invalid/',
         'item_dir': temp_dir.name,
         'cookie_jar': '{}/cookies.txt'.format(temp_dir.name),
         'warc_file_base': 'preflight.invalid',

--- a/pipeline/pipeline.py
+++ b/pipeline/pipeline.py
@@ -133,6 +133,9 @@ wpull_args = WpullArgs(
     monitor_disk=WPULL_MONITOR_DISK,
     monitor_memory=WPULL_MONITOR_MEMORY,
 )
+
+check_wpull_args(wpull_args)
+
 wpull_env = {
     'ITEM_IDENT': ItemInterpolation('%(ident)s'),
     'LOG_KEY': ItemInterpolation('%(log_key)s'),
@@ -186,8 +189,6 @@ pipeline.on_stop_requested += status_stopping
 
 # Activate system monitoring.
 monitoring.start(pipeline, control, VERSION, downloader)
-
-check_wpull_args(wpull_args)
 
 print('*' * 60)
 print('Pipeline ID: %s' % pipeline_id)


### PR DESCRIPTION
* Run the preflight test in the pipeline directory to avoid issues from different file systems (e.g. small /tmp, causing the disk space checker to pause everything).
* Replace the pseudo-invalid test domain with one that can never be valid.
* Run the preflight test before pipeline registration so failures don't require control node cleanup.