### PR TITLE
Bump dnspython to 1.16.0

### DIFF
--- a/pipeline/archivebot/seesaw/dnspythoncrash.py
+++ b/pipeline/archivebot/seesaw/dnspythoncrash.py
@@ -1,0 +1,63 @@
+# Tests whether dnspython's is_multicast is broken. Compatible with dnspython 1.15 and 1.16; patches internals of dnspython and so may easily break on other versions.
+# Relevant issues: https://github.com/ArchiveTeam/wpull/issues/365 https://github.com/rthalley/dnspython/issues/302
+
+
+import dns.query
+import dns.rcode
+import dns.resolver
+import socket
+import sys
+
+
+def nowait(*args):
+	pass
+
+
+class TriggerSocket(socket.socket):
+	'''A socket that triggers dnspython's ValueError crash'''
+	def __init__(self, *args, **kwargs):
+		super().__init__(*args, **kwargs)
+		self.__targetAddress = None
+		self.__query = None
+		self.__recvCount = 0
+
+	def sendto(self, data, destination):
+		self.__query = dns.message.from_wire(data)
+		self.__targetAddress = destination
+
+	def recvfrom(self, bufsize):
+		self.__recvCount += 1
+		if self.__recvCount == 1:
+			# First call, return bogus multicast
+			return b'fuckyou', ('255.255.255.255', 12345)
+		else:
+			# Second or later call, return NXDOMAIN
+			r = dns.message.make_response(self.__query)
+			r.set_rcode(dns.rcode.NXDOMAIN)
+			return r.to_wire(), self.__targetAddress
+
+
+def test():
+	origWaitReadable = dns.query._wait_for_readable
+	dns.query._wait_for_readable = nowait
+	origWaitWritable = dns.query._wait_for_writable
+	dns.query._wait_for_writable = nowait
+	origSocketFactory = dns.query.socket_factory
+	dns.query.socket_factory = TriggerSocket
+	try:
+		# With ignore_unexpected = True, this would return the NXDOMAIN response, but dnspython doesn't set that by default.
+		# This means that dns.query.udp raises a dns.query.UnexpectedSource exception instead of handling the actual response and returning NXDOMAIN.
+		# But at least it shouldn't crash with a ValueError...
+		dns.query.udp(dns.message.make_query('example.org', 'A'), '1.1.1.1')
+	except dns.query.UnexpectedSource:
+		return True
+	except ValueError:
+		return False
+	finally:
+		dns.query._wait_for_readable = origWaitReadable
+		dns.query._wait_for_writable = origWaitWritable
+		dns.query.socket_factory = origSocketFactory
+
+
+if __name__ == '__main__':
+	sys.exit(int(not test())) # True, indicating a successful test, becomes False, and int(False) = 0. Similarly, False becomes 1.

--- a/pipeline/pipeline.py
+++ b/pipeline/pipeline.py
@@ -25,6 +25,7 @@ from archivebot import shared_config
 from archivebot.seesaw import extensions
 from archivebot.seesaw import monitoring
 from archivebot.seesaw.preflight import check_wpull_args
+from archivebot.seesaw.dnspythoncrash import test as dnspython_crash_fixed
 from archivebot.seesaw.wpull import WpullArgs
 from archivebot.seesaw.tasks import GetItemFromQueue, StartHeartbeat, \
     SetFetchDepth, PreparePaths, Wpull, CompressLogIfFailed, WriteInfo, DownloadUrlFile, \
@@ -71,6 +72,8 @@ if StrictVersion(seesaw.__version__) < StrictVersion("0.1.8b1"):
 assert downloader not in ('ignorednick', 'YOURNICKHERE'), 'please use a real nickname'
 
 assert datetime.datetime.now(datetime.timezone.utc).astimezone().tzinfo.utcoffset(None).seconds == 0, 'Please set the time zone to UTC'
+
+assert dnspython_crash_fixed(), 'Broken crash-prone dnspython found'
 
 REDIS_URL = env['REDIS_URL']
 LOG_CHANNEL = shared_config.log_channel()

--- a/pipeline/requirements.txt
+++ b/pipeline/requirements.txt
@@ -11,3 +11,4 @@ lxml
 lmdb
 youtube-dl
 html5lib==0.9999999
+dnspython==1.16.0


### PR DESCRIPTION
wpull depends on dnspython3, which is only a transitional package nowadays and hasn't been updated after 1.15.0, so that version is always used.

Supersedes #339, cf. ArchiveTeam/wpull#365.