### PR TITLE
ignoresets: add some XenForo ignores

### DIFF
--- a/db/ignore_patterns/forums.json
+++ b/db/ignore_patterns/forums.json
@@ -66,7 +66,10 @@
         "/discussion/comment/\\d+/(cry|persevere|triumph|frowning|anguished|fearful|weary|sleepy|tired_face|grimace|bawling|open_mouth|hushed|cold_sweat|scream|astonished|flushed|sleeping|dizzy|no_mouth|mask|star|cookie|warning|mrgreen|heart|heartbreak|kiss|\\+1|-1|grey_question|trollface|grey_question)\\.png",
         "/discussion/\\d+/(cry|persevere|triumph|frowning|anguished|fearful|weary|sleepy|tired_face|grimace|bawling|open_mouth|hushed|cold_sweat|scream|astonished|flushed|sleeping|dizzy|no_mouth|mask|star|cookie|warning|mrgreen|heart|heartbreak|kiss|\\+1|-1|grey_question|trollface|grey_question)\\.png",
         "/discussion/votecomment/",
-        "/discussion/flag/"
+        "/discussion/flag/",
+        "/posts/\\d+/share$",
+        "/threads/[^/]*\\.\\d+/page-%page%$",
+        "/threads/[^/]*\\.\\d+/poll/vote$"
     ],
     "type": "ignore_patterns"
 }


### PR DESCRIPTION
`/share` is a "Share this post" page that contains no useful information (e.g. https://www.emutalk.net/posts/134368/share and https://www.emutalk.net/posts/123040/share).
`/page-%page%` is from a data attribute used for a page selector, but there's also a regular page selector that uses normal links so it can just be ignored.
`/poll/vote` is the (POST) action on a form tag (and can't be used without an account).