### PR TITLE
Updated singletumblr igset and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 *.sw?
 *.rdb
+.DS_Store
+Thumbs.db
+desktop.ini
 
 data
 ./wget-lua

--- a/db/ignore_patterns/singletumblr.json
+++ b/db/ignore_patterns/singletumblr.json
@@ -1,7 +1,7 @@
 {
     "name": "singletumblr",
     "patterns": [
-        "^https?://(?!({primary_netloc}|(\\d+|v[aefpt])\\.media\\.tumblr\\.com|assets\\.tumblr\\.com|a\\.tumblr\\.com)(:\\d+)?/|www\\.tumblr\\.com/video/)([^/]*\\.)?tumblr\\.com(:\\d+)?/"
+        "^https?://(?!({primary_netloc}|(\\d+|v[aefpt])\\.media\\.tumblr\\.com|assets\\.tumblr\\.com|a\\.tumblr\\.com|static\\.tumblr\\.com)(:\\d+)?/|www\\.tumblr\\.com/video/)([^/]*\\.)?tumblr\\.com(:\\d+)?/"
     ],
     "type": "ignore_patterns"
 }


### PR DESCRIPTION
**ArchiveBot/db/ignore_patterns/singletumblr.json:**
- Included `static.tumblr.com` in negative lookahead.

**ArchiveBot/.gitignore:**
- Included `.DS_Store`, `Thumbs.db` and `desktop.ini` filesystem lint macOS and Windows hosts often create.