### PR TITLE
Remove stray backtick from !ignore docs

### DIFF
--- a/doc/commands.rst
+++ b/doc/commands.rst
@@ -332,7 +332,7 @@ Examples
     ``{primary_url}`` will be ``http://www.example.com/foo.html`` and
     ``{primary_netloc}`` will be ``www.example.com``.
 
-    When retriving requisites of ``http://www.bar.org:8080/qux.html```,
+    When retriving requisites of ``http://www.bar.org:8080/qux.html``,
     ``{primary_url}`` will be ``http://www.bar.org:8080/qux.html`` and
     ``{primary_netloc}`` will be ``www.bar.org:8080``.
 


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/8334194/188054216-3b0d60c3-4cab-4ac5-bb1b-6896ace40a00.png)
