### PR TITLE
Add additional github ignores

### DIFF
--- a/db/ignore_patterns/github.json
+++ b/db/ignore_patterns/github.json
@@ -22,6 +22,8 @@
 		"^https?://github\\.com/[^/]+/[^/]+/(issues|pull)/[^/]+/hovercard$",
 		"^https?://github\\.com/[^/]+/[^/]+/packages\\?(.*&)?sort_by=",
 		"^https?://github\\.com/[^/]+/[^/]+/used_by_list$",
+		"^https?://github\\.com/[^/]+/[^/]+/sponsor_button$",
+		"^https?://github\\.com/[^/]+/[^/]+/hovercards/citation/sidebar_partial\\?tree_name=",
 		"^https?://github\\.com/.*/(contributions-spider-graph|drag-drop|jump-to|profile-pins-element|randomColor|sortable-behavior|tweetsodium|user-status-submit)\\.js$"
 	],
 	"type": "ignore_patterns"


### PR DESCRIPTION
Both of these are 406. `/sponsor_button` only appears on some repos, such as [this one](https://github.com/devkitPro/libogc/). `/hovercards/citation/sidebar_partial?tree_name=master` appears everywhere (but seems to usually be a 204 No Content outside of ArchiveBot). `/sponsors_list`, not included here, does work fine.