### PR TITLE
Globally ignore s7.addthis.com

### DIFF
--- a/db/ignore_patterns/global.json
+++ b/db/ignore_patterns/global.json
@@ -213,7 +213,8 @@
         "^https?://((videos|360)\\.littlstar\\.com|ls-video-masters\\.s3-accelerate\\.amazonaws\\.com)/.*\\.(mp4|mov|mkv|webm|avi|yuv|y4m)$",
         "^https?://platform\\.iteratehq\\.com/[0-9a-f-]+\\.png$",
         "^https?://accounts\\.google\\.com/(ServiceLogin|AccountChooser)\\?",
-        "^https://discord\\.com/assets/"
+        "^https://discord\\.com/assets/",
+        "^https?://s7\\.addthis\\.com/"
     ],
     "type": "ignore_patterns"
 }


### PR DESCRIPTION
This appears on a lot of sites, and almost always times out, slowing down jobs. Other addthis.com domains are already ignored.