### PR TITLE
Add Google and Outlook calendars to global ignoreset

### DIFF
--- a/db/ignore_patterns/global.json
+++ b/db/ignore_patterns/global.json
@@ -216,7 +216,7 @@
         "^https://discord\\.com/assets/",
         "^https?://s7\\.addthis\\.com/",
         "^https?://www\\.google\\.com/calendar/(render|event)\\?",
-        "^https?://outlook\\.(office|live)\\.com/owa/\\?"
+        "^https?://outlook\\.(office|live)\\.com/owa/?\\?"
     ],
     "type": "ignore_patterns"
 }

--- a/db/ignore_patterns/global.json
+++ b/db/ignore_patterns/global.json
@@ -214,7 +214,9 @@
         "^https?://platform\\.iteratehq\\.com/[0-9a-f-]+\\.png$",
         "^https?://accounts\\.google\\.com/(ServiceLogin|AccountChooser)\\?",
         "^https://discord\\.com/assets/",
-        "^https?://s7\\.addthis\\.com/"
+        "^https?://s7\\.addthis\\.com/",
+        "^https?://www\\.google\\.com/calendar/(render|event)\\?",
+        "^https?://outlook\\.(office|live)\\.com/owa/\\?"
     ],
     "type": "ignore_patterns"
 }


### PR DESCRIPTION
These are often generated by the [Tribe](https://tri.be/our-work/the-events-calendar/) [events calendar](https://theeventscalendar.com/) on wordpress sites, and always redirect to a generic login page (or an information page for the outlook.live.com variant). These pages aren't useful to save (especially as even if you have an account on one of these services, loading the login page on web.archive.org won't be helpful).

See demo pages [here](https://demo.theeventscalendar.com/events/month/) and [here](https://demo.theeventscalendar.com/event/cooking-for-busy-healthy-people/2023-03-14/). ArchiveBot doesn't do anything with the iCalendar link. The .ics links are per-site, and could maybe be added to the blogs igset (but these calendars also need manual work to limit pagination, so I don't think that's as useful).