### PR TITLE
dashboard: gzip- or deflate-compress the /logs/recent response if the browser accepts the encoding

### DIFF
--- a/dashboard/resources/recent.rb
+++ b/dashboard/resources/recent.rb
@@ -26,6 +26,10 @@ class Recent < Webmachine::Resource
     ]
   end
 
+  def encodings_provided
+    {'gzip' => :encode_gzip, 'deflate' => :encode_deflate, 'identity' => :encode_identity}
+  end
+
   def to_json
     response.headers['Access-Control-Allow-Origin'] = '*'
     count = [[request.query['count'] ? request.query['count'].to_i : 10, 10].min, 1].max


### PR DESCRIPTION
The ArchiveBot web server currently does not compress the ~2MB `/logs/recent` response, even when the browser sends `Accept-Encoding: gzip, deflate`.

This change is intended to speed up the loading of the dashboard over slower connections.

I based this on an example, but I haven't tested this because I lacked a testing environment.