### PR TITLE
When a new job is added, don't scroll the stopped logged window being hovered over

### DIFF
--- a/dashboard/assets/scripts/dashboard.js
+++ b/dashboard/assets/scripts/dashboard.js
@@ -663,6 +663,10 @@ class JobsRenderer {
 		// Hidden log windows aren't scrolled down while lines are added to them,
 		// but now that more are visible, we need to scroll them to the bottom.
 		for (const w of matchedWindows) {
+			// Don't scroll log windows we're mousing over
+			if (w.classList.contains("log-window-stopped")) {
+				continue;
+			}
 			scrollToBottom(w);
 		}
 	}


### PR DESCRIPTION
This fixes:

"when you hover over a log window, it stops scrolling as intended, but each time a new job is added at the top of the dashboard, the log window scrolls to the bottom. I'm pretty sure this wasn't the case before [...]."

Reported by @JustAnotherArchivist 

Diagnosis:

`JobsRenderer._createLogContainer` calls `this.applyFilter()`; `applyFilter` was scrolling all the log windows (with the intention of scrolling log windows made newly visible by the filter), but neglected to check whether they were `log-window-stopped`.