### PR TITLE
Reenable unsafe renegotiation (cf. RFC 5746) and update openssl.conf for OpenSSL 3.x

### DIFF
--- a/ops/openssl-less-secure.cnf
+++ b/ops/openssl-less-secure.cnf
@@ -1,2 +1,12 @@
+openssl_conf = openssl_init
+
+[openssl_init]
+ssl_conf = ssl_sect
+
+[ssl_sect]
+system_default = system_default_sect
+
+[system_default_sect]
 MinProtocol = None
 CipherString = ALL
+Options = UnsafeLegacyRenegotiation


### PR DESCRIPTION
Since OpenSSL 3.0, legacy renegotiation is disabled. This leads to 'Operation not permitted' errors e.g. on https://josour.unescwa.org/. With curl, it manifests as 'OpenSSL/3.0.11: error:0A000152:SSL routines::unsafe legacy renegotiation disabled'. Notably, browsers have no issues connecting there.

Further, the config file format apparently has to be more complicated now. It's still compatible with OpenSSL 1.1.1 though. I did not test older versions since they're irrelevant by now.