### PR TITLE
nosortedindex: Add alternate syntax

### DIFF
--- a/db/ignore_patterns/nosortedindex.json
+++ b/db/ignore_patterns/nosortedindex.json
@@ -1,7 +1,7 @@
 {
     "name": "nosortedindex",
     "patterns": [
-        "\\?C=[NMSD];O=[AD]$"
+        "\\?C=[NMSD][;&]O=[AD]$"
     ],
     "type": "ignore_patterns"
 }


### PR DESCRIPTION
Recently I encountered a few jobs using software using a syntax like `?C=N&0=A` instead of `?C=N;0=A` for sorting index lists. This usually gets noticed only after a fair amount of those URLs made it into the job already. For that reason I’d like to add it to the ignoreset.