### PR TITLE
Ignore Google and Outlook calendar links from the All-In-One Event Calendar (ai1ec) WordPress plugin

### DIFF
--- a/db/ignore_patterns/blogs.json
+++ b/db/ignore_patterns/blogs.json
@@ -33,7 +33,9 @@
         "^https?://www\\.dreamwidth\\.org/tools/(memadd|tellafriend)\\?",
         "^https?://[^\\.]+\\.dreamwidth\\.org/.+[\\?&]mode=reply",
         "[?&]SuperSocializerAuth=(LiveJournal|Twitch|Twitter|Xing)(&|$)",
-        "^https?://wordpress\\.com/log-in\\?"
+        "^https?://wordpress\\.com/log-in\\?",
+        "^https?://www\\.google\\.com/calendar/render\\?",
+        "^https?://outlook\\.(office|live)\\.com/owa\\?"
     ],
     "type": "ignore_patterns"
 }


### PR DESCRIPTION
Cf. https://github.com/ArchiveTeam/wpull/issues/489 though they've been useless before that already, too.