### PR TITLE
Add video.seattle.gov to badvideos ignore set

### DIFF
--- a/db/ignore_patterns/badvideos.json
+++ b/db/ignore_patterns/badvideos.json
@@ -12,7 +12,8 @@
 		"^https?://video\\.csfd\\.cz/files/videos/",
 		"^https?://assets\\d*\\.ign\\.com/videos/zencoder/.*\\.mp4$",
 		"^https?://s3\\.amazonaws\\.com/o\\.videoarchive\\.ign\\.com/.*\\.mp4$",
-		"^https?://(cuts\\.diamond|mlb-cuts-diamond)\\.mlb\\.com/FORGE/.*\\.mp4$"
+		"^https?://(cuts\\.diamond|mlb-cuts-diamond)\\.mlb\\.com/FORGE/.*\\.mp4$",
+		"^https?://video\\.seattle\\.gov/"
 	],
 	"type": "ignore_patterns"
 }


### PR DESCRIPTION
https://video.seattle.gov/ contains various large videos from the Seattle government. These are generally discovered from https://seattlechannel.org/ (which is in turn usually discovered from various local political sites).

The content is already mirrored at https://archive.org/details/seattlemunicipalarchives?tab=about or https://archive.org/details/sc21wa?tab=about (though the latter technically mirrors https://www.youtube.com/@SeattleChannel21/videos which has the same content). For instance, https://seattlechannel.org/videos?videoid=x159555 is mirrored at https://archive.org/details/sc21wa-Mayor_Harrell_unveils_bonus_rebates_for_heat_pump_upgrades (from https://www.youtube.com/watch?v=gC9TGn238Sc).