### PR TITLE
Add twemoji.maxcdn.com to the global ignore set

### DIFF
--- a/db/ignore_patterns/global.json
+++ b/db/ignore_patterns/global.json
@@ -217,7 +217,8 @@
         "^https://discord\\.com/assets/",
         "^https?://s7\\.addthis\\.com/",
         "^https?://www\\.google\\.com/calendar/(render|event)\\?",
-        "^https?://outlook\\.(office|live)\\.com/owa/?\\?"
+        "^https?://outlook\\.(office|live)\\.com/owa/?\\?",
+        "^https?://twemoji\\.maxcdn\\.com/"
     ],
     "type": "ignore_patterns"
 }


### PR DESCRIPTION
See https://web.archive.org/web/20220505195500/https://blog.stackpath.com/maxcdn-and-securecdn-are-retiring-heres-what-it-means-for-you/ and https://github.com/twitter/twemoji/issues/556 for context. Based on e.g. https://web.archive.org/web/20240710000000*/https://twemoji.maxcdn.com/2/72x72/1f43e.png it looks like twemoji.maxcdn.com used to redirect to cdn.jsdelivr.net (possibly with an invalid certificate, which archivebot ignores), but recently started timing out.