### PR TITLE
Improve the dashboard with lots of fixes and features

### DIFF
--- a/dashboard/assets/scripts/dashboard.js
+++ b/dashboard/assets/scripts/dashboard.js
@@ -492,10 +492,12 @@ class JobsRenderer {
 			logSegment.appendChild(h("div", Reusable.obj_className_line_stdout, line));
 			renderedLines += 1;
 
-			// Check for 'Finished RsyncUpload for Item'
-			// instead of 'Starting MarkItemAsDone for Item'
-			// because the latter is often missing
-			if (/^Finished RsyncUpload for Item/.test(line)) {
+			// Check for several completion messages
+			// because some of them are often missing
+			// Ignore error jobs as they get done messages.
+			if (!info.statsElements.jobInfo.classList.contains("job-info-fatal") &&
+			    !info.statsElements.jobInfo.classList.contains("job-info-aborted") &&
+			    /^ *[1-9][0-9]* bytes\.$|^Starting (RelabelIfAborted|MarkItemAsDone) for Item$|^Finished (WgetDownload|MoveFiles|StopHeartbeat) for Item$/.test(line)) {
 				info.statsElements.jobInfo.classList.add("job-info-done");
 				this.jobs.markFinished(ident);
 			} else if (

--- a/dashboard/assets/scripts/dashboard.js
+++ b/dashboard/assets/scripts/dashboard.js
@@ -628,14 +628,14 @@ class JobsRenderer {
 	}
 
 	applyFilter() {
-		const query = this.filterBox.value;
+		const query = RegExp(this.filterBox.value);
 		let matches = 0;
 		const matchedWindows = [];
 		const unmatchedWindows = [];
 		this.firstFilterMatch = null;
 		for (const job of this.jobs.sorted) {
 			const w = this.renderInfo[job.ident].logWindow;
-			if (!RegExp(query).test(job.url)) {
+			if (!query.test(job.url)) {
 				w.classList.add("log-window-hidden");
 
 				unmatchedWindows.push(w);

--- a/dashboard/assets/scripts/dashboard.js
+++ b/dashboard/assets/scripts/dashboard.js
@@ -370,7 +370,11 @@ class JobsRenderer {
 			queueLength: h("span", { className: `inline-stat ${maybeAligned("job-in-queue")}` }, "? in q."),
 			connections: h("span", { className: `inline-stat ${maybeAligned("job-connections")}` }, "?"),
 			delay: h("span", { className: `inline-stat ${maybeAligned("job-delay")}` }, "? ms delay"),
-			ignores: h("span", { className: "job-ignores" }, "?"),
+			ignores: h("a", {
+				className: "job-ignores",
+				href: `//${ds.host}${ds.port}/ignores/${ident}?compact=true`,
+				onclick: (ev) => { ev.stopPropagation(); },
+			}, "?" ),
 			jobInfo: null /* set later */,
 		};
 

--- a/dashboard/assets/scripts/dashboard.js
+++ b/dashboard/assets/scripts/dashboard.js
@@ -225,10 +225,11 @@ class JobsTracker {
 }
 
 class JobRenderInfo {
-	constructor(logWindow, logSegment, statsElements, jobNote, lineCountWindow, lineCountSegments) {
+	constructor(logWindow, logSegment, statsElements, jobUrl, jobNote, lineCountWindow, lineCountSegments) {
 		this.logWindow = logWindow;
 		this.logSegment = logSegment;
 		this.statsElements = statsElements;
+		this.jobUrl = jobUrl;
 		this.jobNote = jobNote;
 		this.lineCountWindow = lineCountWindow;
 		this.lineCountSegments = lineCountSegments;
@@ -411,13 +412,14 @@ class JobsRenderer {
 				],
 			),
 		]);
+		const jobUrl = statsElements.jobInfo.querySelector(".job-url");
 
 		const logWindow = h("div", logWindowAttrs, logSegment);
 		const div = h("div", { className: "log-container", id: `log-container-${ident}` }, [
 			h("div", { className: "job-header" }, [statsElements.jobInfo, h("span", { className: "job-ident" }, ident)]),
 			logWindow,
 		]);
-		this.renderInfo[ident] = new JobRenderInfo(logWindow, logSegment, statsElements, jobNote, 0, [0]);
+		this.renderInfo[ident] = new JobRenderInfo(logWindow, logSegment, statsElements, jobUrl, jobNote, 0, [0]);
 		this.container.insertBefore(div, beforeElement);
 		// Filter hasn't changed, but we might need to filter out the new job, or
 		// add/remove log-window-expanded class
@@ -580,6 +582,11 @@ class JobsRenderer {
 
 		// Update note
 		info.jobNote.textContent = isBlank(jobData.note) ? "" : ` (${jobData.note})`;
+		if (isBlank(jobData.note)) {
+			info.jobUrl.removeAttribute("title");
+		} else {
+			info.jobUrl.title = jobData.note;
+		}
 
 		info.lineCountWindow += linesRendered;
 		info.lineCountSegments[info.lineCountSegments.length - 1] += linesRendered;

--- a/dashboard/assets/scripts/dashboard.js
+++ b/dashboard/assets/scripts/dashboard.js
@@ -693,7 +693,13 @@ class JobsRenderer {
 		this.firstFilterMatch = null;
 		for (const job of this.jobs.sorted) {
 			const w = this.renderInfo[job.ident].logWindow;
-			if (!query.test(job.url)) {
+			const show =
+			(byId("filter-job-id").checked && query.test(job.ident)) ||
+			(byId("filter-job-url").checked && query.test(job.url)) ||
+			(byId("filter-job-note").checked && query.test(job.note)) ||
+			(byId("filter-job-pipeline").checked && (query.test(job.pipeline_id) || query.test(this.pipelines[job.pipeline_id]))) ||
+			(this.showNicks && byId("filter-job-nick").checked && query.test(job.started_by));
+			if (!show) {
 				w.classList.add("log-window-hidden");
 
 				unmatchedWindows.push(w);
@@ -1086,6 +1092,11 @@ class Dashboard {
 		const showNicks = args.showNicks ? Boolean(Number(args.showNicks)) : false;
 		const contextMenu = args.contextMenu ? Boolean(Number(args.contextMenu)) : true;
 		this.initialFilter = args.initialFilter ?? "^$";
+		const filterJobID = args.filterJobID ? Boolean(Number(args.filterJobID)) : true;
+		const filterJobURL = args.filterJobURL ? Boolean(Number(args.filterJobURL)) : true;
+		const filterJobNote = args.filterJobNote ? Boolean(Number(args.filterJobNote)) : true;
+		const filterJobPipe = args.filterJobPipe ? Boolean(Number(args.filterJobPipe)) : true;
+		const filterJobNick = args.filterJobNick ? Boolean(Number(args.filterJobNick)) : true;
 		const showAllHeaders = args.showAllHeaders ? Boolean(Number(args.showAllHeaders)) : true;
 		const showRunningJobs = args.showRunningJobs ? Boolean(Number(args.showRunningJobs)) : true;
 		const showFinishedJobs = args.showFinishedJobs ? Boolean(Number(args.showFinishedJobs)) : true;
@@ -1144,6 +1155,29 @@ class Dashboard {
 
 		if (!showNicks) {
 			addPageStyles(".job-nick-aligned { width: 0; }");
+		} else {
+			byId("filter-types").lastChild.after(
+				h("input", {
+					type: "checkbox",
+					id: "filter-job-nick",
+					onclick: () => { ds.jobsRenderer.applyFilter(); },
+					checked: true,
+				})
+			);
+			byId("filter-types").lastChild.after("\n\t\t\t");
+			byId("filter-types").lastChild.after(
+				h("label", { className: "filter-job", htmlFor: "filter-job-nick", textContent: "Nick" }),
+			);
+			byId("filter-types").lastChild.after(h("br"));
+			byId("filter-types").lastChild.after("\n");
+		}
+
+		byId("filter-job-id").checked = filterJobID;
+		byId("filter-job-url").checked = filterJobURL;
+		byId("filter-job-note").checked = filterJobNote;
+		byId("filter-job-pipeline").checked = filterJobPipe;
+		if (showNicks) {
+			byId("filter-job-nick").checked = filterJobNick;
 		}
 
 		if (args.initialFilter != null) {
@@ -1329,6 +1363,12 @@ ${String(kbPerSec).padStart(3, "0")} KB/s`;
 			ds.showFatalJobs(!byId("show-fatal-jobs").checked);
 		} else if (ev.which === 115 /* s */) {
 			ds.showAbortedJobs(!byId("show-aborted-jobs").checked);
+		} else if (ev.which === 117 /* u */) {
+			byId("filter-job-url").click();
+		} else if (ev.which === 101 /* e */) {
+			byId("filter-job-note").click();
+		} else if (ev.which === 112 /* p */) {
+			byId("filter-job-pipeline").click();
 		}
 	}
 

--- a/dashboard/assets/scripts/dashboard.js
+++ b/dashboard/assets/scripts/dashboard.js
@@ -309,6 +309,7 @@ class JobsRenderer {
 		this.mouseInside = null;
 		this.numCrawls = byId("num-crawls");
 		this._aligned = true;
+		this.pipelines = {};
 	}
 
 	_getNextJobInSorted(ident) {
@@ -323,6 +324,10 @@ class JobsRenderer {
 
 	_createLogSegment() {
 		return h("div");
+	}
+
+	updatePipelines(pipelines) {
+		this.pipelines = pipelines;
 	}
 
 	_createLogContainer(jobData) {
@@ -1093,6 +1098,8 @@ class Dashboard {
 			this.contextMenuRenderer,
 		);
 
+		this.loadPipelines();
+
 		document.onkeypress = (ev) => this.keyPress(ev);
 
 		// Adjust help text based on URL
@@ -1190,6 +1197,31 @@ ${String(kbPerSec).padStart(3, "0")} KB/s`;
 		} else {
 			finishSetup();
 		}
+	}
+
+	loadPipelines() {
+		return new Promise((resolve, reject) => {
+			const xhr = new XMLHttpRequest();
+			xhr.onload = () => {
+				try {
+					let pipelines = {};
+					const json = JSON.parse(xhr.responseText).pipelines;
+					for (const pipeline of json) {
+						pipelines[pipeline.id] = pipeline.nickname;
+					}
+					this.jobsRenderer.updatePipelines(pipelines);
+				} catch (e) {
+					console.log("Failed to load /pipelines data: ", e);
+				}
+				resolve();
+			};
+			xhr.onerror = (ev) => {
+				reject(ev);
+			};
+			xhr.open("GET", `//${this.host}${this.port}/pipelines`);
+			xhr.setRequestHeader("Accept", "application/json");
+			xhr.send("");
+		});
 	}
 
 	loadRecent() {

--- a/dashboard/assets/scripts/dashboard.js
+++ b/dashboard/assets/scripts/dashboard.js
@@ -1039,6 +1039,10 @@ class Dashboard {
 		const contextMenu = args.contextMenu ? Boolean(Number(args.contextMenu)) : true;
 		this.initialFilter = args.initialFilter ?? "^$";
 		const showAllHeaders = args.showAllHeaders ? Boolean(Number(args.showAllHeaders)) : true;
+		const showRunningJobs = args.showRunningJobs ? Boolean(Number(args.showRunningJobs)) : true;
+		const showFinishedJobs = args.showFinishedJobs ? Boolean(Number(args.showFinishedJobs)) : true;
+		const showFatalJobs = args.showFatalJobs ? Boolean(Number(args.showFatalJobs)) : true;
+		const showAbortedJobs = args.showAbortedJobs ? Boolean(Number(args.showAbortedJobs)) : true;
 		const loadRecent = args.loadRecent ? Boolean(Number(args.loadRecent)) : true;
 		this.debug = args.debug ? Boolean(Number(args.debug)) : false;
 
@@ -1106,6 +1110,11 @@ class Dashboard {
 		this.setFilter(this.initialFilter);
 
 		this.showAllHeaders(showAllHeaders);
+
+		this.showRunningJobs(showRunningJobs);
+		this.showFinishedJobs(showFinishedJobs);
+		this.showFatalJobs(showFatalJobs);
+		this.showAbortedJobs(showAbortedJobs);
 
 		const finishSetup = () => {
 			byId("meta-info").innerHTML = "";
@@ -1233,6 +1242,14 @@ ${String(kbPerSec).padStart(3, "0")} KB/s`;
 			window.open(this.jobsRenderer.firstFilterMatch.url);
 		} else if (ev.which === 104 /* h */) {
 			ds.showAllHeaders(!byId("show-all-headers").checked);
+		} else if (ev.which === 114 /* r */) {
+			ds.showRunningJobs(!byId("show-running-jobs").checked);
+		} else if (ev.which === 100 /* d */) {
+			ds.showFinishedJobs(!byId("show-finished-jobs").checked);
+		} else if (ev.which === 99 /* c */) {
+			ds.showFatalJobs(!byId("show-fatal-jobs").checked);
+		} else if (ev.which === 115 /* s */) {
+			ds.showAbortedJobs(!byId("show-aborted-jobs").checked);
 		}
 	}
 
@@ -1291,6 +1308,26 @@ ${String(kbPerSec).padStart(3, "0")} KB/s`;
 	showAllHeaders(value) {
 		byId('show-all-headers').checked = value;
 		byId('hide-headers').sheet.disabled = value;
+	}
+
+	showRunningJobs(value) {
+		byId('show-running-jobs').checked = value;
+		byId('hide-running').sheet.disabled = value;
+	}
+
+	showFinishedJobs(value) {
+		byId('show-finished-jobs').checked = value;
+		byId('hide-done').sheet.disabled = value;
+	}
+
+	showFatalJobs(value) {
+		byId('show-fatal-jobs').checked = value;
+		byId('hide-fatal').sheet.disabled = value;
+	}
+
+	showAbortedJobs(value) {
+		byId('show-aborted-jobs').checked = value;
+		byId('hide-aborted').sheet.disabled = value;
 	}
 }
 

--- a/dashboard/assets/scripts/dashboard.js
+++ b/dashboard/assets/scripts/dashboard.js
@@ -5,6 +5,10 @@
 
 "use strict";
 
+String.prototype.removePrefix = function (prefix) {
+    return this.startsWith(prefix) ? this.substr(prefix.length) : this.toString();
+};
+
 function assert(condition, message) {
 	if (!condition) {
 		throw message || "Assertion failed";
@@ -326,8 +330,22 @@ class JobsRenderer {
 		return h("div");
 	}
 
+	pipelineInfo(job) {
+		const pipeline_id = job.pipeline_id;
+		const pipeline_just_id = pipeline_id.removePrefix("pipeline:");
+		const pipeline_nick = this.pipelines[pipeline_id];
+		return [
+			`pipeline ${pipeline_nick ?? "unknown"} ${pipeline_just_id}`,
+			pipeline_nick ?? pipeline_just_id,
+		]
+	}
+
 	updatePipelines(pipelines) {
 		this.pipelines = pipelines;
+		for (const job of this.jobs.sorted) {
+			const pipeline = this.renderInfo[job.ident].statsElements.pipeline;
+			[pipeline.title, pipeline.textContent] = this.pipelineInfo(job);
+		}
 	}
 
 	_createLogContainer(jobData) {
@@ -368,6 +386,9 @@ class JobsRenderer {
 			return s;
 		};
 
+
+		const [pipeline_title, pipeline_text] = this.pipelineInfo(jobData);
+
 		const statsElements = {
 			mb: h("span", { className: `inline-stat ${maybeAligned("job-mb")}` }, "?"),
 			responses: h("span", { className: `inline-stat ${maybeAligned("job-responses")}` }, "?"),
@@ -380,6 +401,12 @@ class JobsRenderer {
 				href: `//${ds.host}${ds.port}/ignores/${ident}?compact=true`,
 				onclick: (ev) => { ev.stopPropagation(); },
 			}, "?" ),
+			pipeline: h("a", {
+				className: `inline-stat ${maybeAligned("job-pipeline")}`,
+				href: `//${ds.host}${ds.port}/pipelines?initialFilter=${jobData.pipeline_id}`,
+				title: pipeline_title,
+				onclick: (ev) => { ev.stopPropagation(); },
+			}, pipeline_text),
 			jobInfo: null /* set later */,
 		};
 
@@ -428,6 +455,8 @@ class JobsRenderer {
 					statsElements.delay,
 					"; ",
 					statsElements.ignores,
+					"; ",
+					statsElements.pipeline,
 				],
 			),
 		]);
@@ -604,6 +633,10 @@ class JobsRenderer {
 				info.statsElements.ignores.classList.remove("job-igoff");
 			}
 		}
+
+		// Update pipeline in case a job is restarted on another pipline
+		const pipeline = info.statsElements.pipeline;
+		[pipeline.title, pipeline.textContent] = this.pipelineInfo(jobData);
 
 		// Update note
 		info.jobNote.textContent = isBlank(jobData.note) ? "" : ` (${jobData.note})`;

--- a/dashboard/assets/scripts/dashboard.js
+++ b/dashboard/assets/scripts/dashboard.js
@@ -1028,6 +1028,7 @@ class Dashboard {
 		const showNicks = args.showNicks ? Boolean(Number(args.showNicks)) : false;
 		const contextMenu = args.contextMenu ? Boolean(Number(args.contextMenu)) : true;
 		this.initialFilter = args.initialFilter ?? "^$";
+		const showAllHeaders = args.showAllHeaders ? Boolean(Number(args.showAllHeaders)) : true;
 		const loadRecent = args.loadRecent ? Boolean(Number(args.loadRecent)) : true;
 		this.debug = args.debug ? Boolean(Number(args.debug)) : false;
 
@@ -1089,6 +1090,8 @@ class Dashboard {
 			byId("set-filter-none").after("\n");
 		}
 		this.setFilter(this.initialFilter);
+
+		this.showAllHeaders(showAllHeaders);
 
 		const finishSetup = () => {
 			byId("meta-info").innerHTML = "";
@@ -1214,6 +1217,8 @@ ${String(kbPerSec).padStart(3, "0")} KB/s`;
 			ds.setFilter(ds.initialFilter);
 		} else if (ev.which === 118 /* v */) {
 			window.open(this.jobsRenderer.firstFilterMatch.url);
+		} else if (ev.which === 104 /* h */) {
+			ds.showAllHeaders(!byId("show-all-headers").checked);
 		}
 	}
 
@@ -1269,6 +1274,11 @@ ${String(kbPerSec).padStart(3, "0")} KB/s`;
 	setFilter(value) {
 		byId("filter-box").value = value;
 		byId("filter-box").onchange();
+	}
+
+	showAllHeaders(value) {
+		byId('show-all-headers').checked = value;
+		byId('hide-headers').sheet.disabled = value;
 	}
 }
 

--- a/dashboard/assets/scripts/dashboard.js
+++ b/dashboard/assets/scripts/dashboard.js
@@ -1038,6 +1038,8 @@ class Dashboard {
 		}
 
 		this.host = args.host ? args.host : location.hostname;
+		this.port = args.port ? `:${Number(args.port)}` : '';
+
 		this.dumpTraffic = args.dumpMax && Number(args.dumpMax) > 0;
 		if (this.dumpTraffic) {
 			this.dumpMax = Number(args.dumpMax);
@@ -1180,7 +1182,7 @@ ${String(kbPerSec).padStart(3, "0")} KB/s`;
 				const size_mb = Math.round((100 * ev.total) / 1e6) / 100;
 				byId("meta-info").textContent = `Recent data: ${percent}% (${size_mb}MB)`;
 			};
-			xhr.open("GET", `//${this.host}/logs/recent?cb=${Date.now()}${Math.random()}`);
+			xhr.open("GET", `//${this.host}${this.port}/logs/recent?cb=${Date.now()}${Math.random()}`);
 			xhr.setRequestHeader("Accept", "application/json");
 			xhr.send("");
 		});

--- a/dashboard/assets/scripts/dashboard.js
+++ b/dashboard/assets/scripts/dashboard.js
@@ -1027,7 +1027,7 @@ class Dashboard {
 		const batchMaxItems = args.batchMaxItems ? Number(args.batchMaxItems) : 250;
 		const showNicks = args.showNicks ? Boolean(Number(args.showNicks)) : false;
 		const contextMenu = args.contextMenu ? Boolean(Number(args.contextMenu)) : true;
-		const initialFilter = args.initialFilter ?? "^$";
+		this.initialFilter = args.initialFilter ?? "^$";
 		const loadRecent = args.loadRecent ? Boolean(Number(args.loadRecent)) : true;
 		this.debug = args.debug ? Boolean(Number(args.debug)) : false;
 
@@ -1076,7 +1076,19 @@ class Dashboard {
 			addPageStyles(".job-nick-aligned { width: 0; }");
 		}
 
-		this.setFilter(initialFilter);
+		if (args.initialFilter != null) {
+			byId("set-filter-none").after(
+				h("input", {
+					className: "button",
+					type: "button",
+					id: "set-filter-initial",
+					onclick: () => { ds.setFilter(ds.initialFilter) },
+					value: "Initial",
+				})
+			);
+			byId("set-filter-none").after("\n");
+		}
+		this.setFilter(this.initialFilter);
 
 		const finishSetup = () => {
 			byId("meta-info").innerHTML = "";
@@ -1198,6 +1210,8 @@ ${String(kbPerSec).padStart(3, "0")} KB/s`;
 			ev.preventDefault();
 			byId("filter-box").focus();
 			byId("filter-box").select();
+		} else if (ev.which === 105 /* i */) {
+			ds.setFilter(ds.initialFilter);
 		} else if (ev.which === 118 /* v */) {
 			window.open(this.jobsRenderer.firstFilterMatch.url);
 		}

--- a/dashboard/assets/scripts/dashboard.js
+++ b/dashboard/assets/scripts/dashboard.js
@@ -497,9 +497,12 @@ class JobsRenderer {
 			// Ignore error jobs as they get done messages.
 			if (!info.statsElements.jobInfo.classList.contains("job-info-fatal") &&
 			    !info.statsElements.jobInfo.classList.contains("job-info-aborted") &&
+			    !info.statsElements.jobInfo.classList.contains("job-info-failed") &&
 			    /^ *[1-9][0-9]* bytes\.$|^Starting (RelabelIfAborted|MarkItemAsDone) for Item$|^Finished (WgetDownload|MoveFiles|StopHeartbeat) for Item$/.test(line)) {
 				info.statsElements.jobInfo.classList.add("job-info-done");
 				this.jobs.markFinished(ident);
+			} else if (/^ *0 bytes\.$/.test(line)) {
+				info.statsElements.jobInfo.classList.add("job-info-failed");
 			} else if (
 				/^CRITICAL (Sorry|Please report)|^ERROR Fatal exception|No space left on device|^Fatal Python error:|^(Thread|Current thread) 0x/.test(
 					line,
@@ -520,6 +523,7 @@ class JobsRenderer {
 			} else if (/^Received item /.test(line)) {
 				// Clear other statuses if a job restarts with the same job ID
 				info.statsElements.jobInfo.classList.remove("job-info-done");
+				info.statsElements.jobInfo.classList.remove("job-info-failed");
 				info.statsElements.jobInfo.classList.remove("job-info-fatal");
 				info.statsElements.jobInfo.classList.remove("job-info-aborted");
 				this.jobs.markUnfinished(ident);
@@ -1043,6 +1047,7 @@ class Dashboard {
 		const showAllHeaders = args.showAllHeaders ? Boolean(Number(args.showAllHeaders)) : true;
 		const showRunningJobs = args.showRunningJobs ? Boolean(Number(args.showRunningJobs)) : true;
 		const showFinishedJobs = args.showFinishedJobs ? Boolean(Number(args.showFinishedJobs)) : true;
+		const showFailedJobs = args.showFailedJobs ? Boolean(Number(args.showFailedJobs)) : true;
 		const showFatalJobs = args.showFatalJobs ? Boolean(Number(args.showFatalJobs)) : true;
 		const showAbortedJobs = args.showAbortedJobs ? Boolean(Number(args.showAbortedJobs)) : true;
 		const loadRecent = args.loadRecent ? Boolean(Number(args.loadRecent)) : true;
@@ -1115,6 +1120,7 @@ class Dashboard {
 
 		this.showRunningJobs(showRunningJobs);
 		this.showFinishedJobs(showFinishedJobs);
+		this.showFailedJobs(showFailedJobs);
 		this.showFatalJobs(showFatalJobs);
 		this.showAbortedJobs(showAbortedJobs);
 
@@ -1248,6 +1254,8 @@ ${String(kbPerSec).padStart(3, "0")} KB/s`;
 			ds.showRunningJobs(!byId("show-running-jobs").checked);
 		} else if (ev.which === 100 /* d */) {
 			ds.showFinishedJobs(!byId("show-finished-jobs").checked);
+		} else if (ev.which === 98 /* b */) {
+			ds.showFailedJobs(!byId("show-failed-jobs").checked);
 		} else if (ev.which === 99 /* c */) {
 			ds.showFatalJobs(!byId("show-fatal-jobs").checked);
 		} else if (ev.which === 115 /* s */) {
@@ -1320,6 +1328,11 @@ ${String(kbPerSec).padStart(3, "0")} KB/s`;
 	showFinishedJobs(value) {
 		byId('show-finished-jobs').checked = value;
 		byId('hide-done').sheet.disabled = value;
+	}
+
+	showFailedJobs(value) {
+		byId('show-failed-jobs').checked = value;
+		byId('hide-failed').sheet.disabled = value;
 	}
 
 	showFatalJobs(value) {

--- a/dashboard/assets/scripts/dashboard.js
+++ b/dashboard/assets/scripts/dashboard.js
@@ -1039,6 +1039,8 @@ class Dashboard {
 
 		this.host = args.host ? args.host : location.hostname;
 		this.port = args.port ? `:${Number(args.port)}` : '';
+		const wsproto = window.location.protocol === "https:" ? "wss:" : "ws:";
+		this.websocketUrl = args.websocketUrl ?? `${wsproto}//${this.host}:4568/stream`;
 
 		this.dumpTraffic = args.dumpMax && Number(args.dumpMax) > 0;
 		if (this.dumpTraffic) {
@@ -1233,9 +1235,7 @@ ${String(kbPerSec).padStart(3, "0")} KB/s`;
 	}
 
 	connectWebSocket() {
-		const wsproto = window.location.protocol === "https:" ? "wss:" : "ws:";
-
-		this.ws = new WebSocket(`${wsproto}//${this.host}:4568/stream`);
+		this.ws = new WebSocket(this.websocketUrl);
 
 		this.ws.onmessage = (ev) => {
 			this.newItemsReceived += 1;

--- a/dashboard/dashboard.html
+++ b/dashboard/dashboard.html
@@ -430,7 +430,7 @@ kbd {
 					<span class="job-info-fatal">finished with fatal exception</span>.
 			</p>
 			<p>
-				Mouse over the job start date or the response count for additional information.
+				Mouse over the job URL, start date, response count or the queue count for additional information.
 			</p>
 			<p>
 				To pause scrolling, move your mouse inside a log window.

--- a/dashboard/dashboard.html
+++ b/dashboard/dashboard.html
@@ -418,6 +418,9 @@ kbd {
 				This page shows all of the crawls that <a href="https://wiki.archiveteam.org/index.php?title=ArchiveBot">ArchiveBot</a> is currently running.
 			</p>
 			<p>
+				Each job has a header with the URL, note, request/queue stats, options and an identifier.
+			</p>
+			<p>
 				To show or hide a job, click anywhere on its stats line.
 
 				The color coding for the job stats line is:

--- a/dashboard/dashboard.html
+++ b/dashboard/dashboard.html
@@ -470,6 +470,7 @@ kbd {
 				<li>To append some text to the page title, add <kbd><span class="url-q-or-amp">?</span>title=TEXT</kbd> to the dashboard URL.</li>
 				<li>To override the hostname of the logs server, add <kbd><span class="url-q-or-amp">?</span>host=TEXT</kbd> to the dashboard URL.</li>
 				<li>To view the first two JSON messages of the logs stream, add <kbd><span class="url-q-or-amp">?</span>dumpMax=2</kbd> to the dashboard URL.</li>
+				<li>To enable debug messages in the browser console, add <kbd><span class="url-q-or-amp">?</span>debug=1</kbd> to the dashboard URL.</li>
 			</ul>
 			<p>
 				To use ArchiveBot, drop by <a href="https://webirc.hackint.org/#irc://irc.hackint.org/archivebot">#archivebot</a> on hackint. <a href="https://archivebot.readthedocs.io/en/latest/">Issue commands</a> by typing them into the channel. You will need channel operator (@) or voice (+) status to issue archiving jobs; just ask for help or leave a message with the website you want to archive.

--- a/dashboard/dashboard.html
+++ b/dashboard/dashboard.html
@@ -481,6 +481,7 @@ kbd {
 				<li>To append some text to the page title, add <kbd><span class="url-q-or-amp">?</span>title=TEXT</kbd> to the dashboard URL.</li>
 				<li>To override the hostname of the logs server, add <kbd><span class="url-q-or-amp">?</span>host=TEXT</kbd> to the dashboard URL.</li>
 				<li>To override the port of the recent logs server, add <kbd><span class="url-q-or-amp">?</span>port=TEXT</kbd> to the dashboard URL.</li>
+				<li>To override the URL of the logs stream, add <kbd><span class="url-q-or-amp">?</span>websocketUrl=ws://localhost:4568/stream</kbd> to the dashboard URL.</li>
 				<li>To view the first two JSON messages of the logs stream, add <kbd><span class="url-q-or-amp">?</span>dumpMax=2</kbd> to the dashboard URL.</li>
 				<li>To enable debug messages in the browser console, add <kbd><span class="url-q-or-amp">?</span>debug=1</kbd> to the dashboard URL.</li>
 			</ul>

--- a/dashboard/dashboard.html
+++ b/dashboard/dashboard.html
@@ -447,6 +447,7 @@ kbd {
 				<li><kbd>a</kbd> - show all job log
 				<li><kbd>n</kbd> - hide all job log
 				<li><kbd>f</kbd> - move focus to filter box
+				<li><kbd>i</kbd> - use the initial job log filter
 				<li><kbd>v</kbd> - open the job URL of the first-shown job log
 				<li><kbd>?</kbd> - show/hide help text
 			</ul>

--- a/dashboard/dashboard.html
+++ b/dashboard/dashboard.html
@@ -468,6 +468,7 @@ kbd {
 				<li>To update the dashboard more frequently, add <kbd><span class="url-q-or-amp">?</span>batchTimeWhenVisible=33</kbd> to the dashboard URL. The default is <code>125</code> (8 Hz).</li>
 				<li>To skip loading of recent (buffered) log data for jobs, add <kbd><span class="url-q-or-amp">?</span>loadRecent=0</kbd> to the dashboard URL. Inactive jobs will not appear.</li>
 				<li>To append some text to the page title, add <kbd><span class="url-q-or-amp">?</span>title=TEXT</kbd> to the dashboard URL.</li>
+				<li>To override the hostname of the logs server, add <kbd><span class="url-q-or-amp">?</span>host=TEXT</kbd> to the dashboard URL.</li>
 			</ul>
 			<p>
 				To use ArchiveBot, drop by <a href="https://webirc.hackint.org/#irc://irc.hackint.org/archivebot">#archivebot</a> on hackint. <a href="https://archivebot.readthedocs.io/en/latest/">Issue commands</a> by typing them into the channel. You will need channel operator (@) or voice (+) status to issue archiving jobs; just ask for help or leave a message with the website you want to archive.

--- a/dashboard/dashboard.html
+++ b/dashboard/dashboard.html
@@ -399,8 +399,8 @@ kbd {
 			tracking <span id="num-crawls">0</span> crawls.
 			See also <a href="pipelines" class="underlined-a">pipeline</a> or <a href="logs/recent" class="underlined-a">job</a> reports.
 			Logs <input id="filter-box" type="text" size="21" title="Show logs for jobs matching this regular expression. For example ^https?://.*">
-			<input onclick="ds.setFilter('');" type="button" value="  All  " class="button">
-			<input onclick="ds.setFilter('^$');" type="button" value="None" class="button">
+			<input id="set-filter-all" onclick="ds.setFilter('');" type="button" value="All"  class="button">
+			<input id="set-filter-none" onclick="ds.setFilter('^$');" type="button" value="None" class="button">
 		</div>
 		<div id="header-right">
 			<div id="meta-info"><span class="adbox">😊</span></div>

--- a/dashboard/dashboard.html
+++ b/dashboard/dashboard.html
@@ -467,6 +467,7 @@ kbd {
 				<li>To retain more lines in the log windows, add <kbd><span class="url-q-or-amp">?</span>historyLines=1000</kbd> to the dashboard URL. The default is <code>500</code>, or <code>250</code> on mobile.</li>
 				<li>To update the dashboard more frequently, add <kbd><span class="url-q-or-amp">?</span>batchTimeWhenVisible=33</kbd> to the dashboard URL. The default is <code>125</code> (8 Hz).</li>
 				<li>To skip loading of recent (buffered) log data for jobs, add <kbd><span class="url-q-or-amp">?</span>loadRecent=0</kbd> to the dashboard URL. Inactive jobs will not appear.</li>
+				<li>To append some text to the page title, add <kbd><span class="url-q-or-amp">?</span>title=TEXT</kbd> to the dashboard URL.</li>
 			</ul>
 			<p>
 				To use ArchiveBot, drop by <a href="https://webirc.hackint.org/#irc://irc.hackint.org/archivebot">#archivebot</a> on hackint. <a href="https://archivebot.readthedocs.io/en/latest/">Issue commands</a> by typing them into the channel. You will need channel operator (@) or voice (+) status to issue archiving jobs; just ask for help or leave a message with the website you want to archive.

--- a/dashboard/dashboard.html
+++ b/dashboard/dashboard.html
@@ -469,6 +469,7 @@ kbd {
 				<li>To skip loading of recent (buffered) log data for jobs, add <kbd><span class="url-q-or-amp">?</span>loadRecent=0</kbd> to the dashboard URL. Inactive jobs will not appear.</li>
 				<li>To append some text to the page title, add <kbd><span class="url-q-or-amp">?</span>title=TEXT</kbd> to the dashboard URL.</li>
 				<li>To override the hostname of the logs server, add <kbd><span class="url-q-or-amp">?</span>host=TEXT</kbd> to the dashboard URL.</li>
+				<li>To view the first two JSON messages of the logs stream, add <kbd><span class="url-q-or-amp">?</span>dumpMax=2</kbd> to the dashboard URL.</li>
 			</ul>
 			<p>
 				To use ArchiveBot, drop by <a href="https://webirc.hackint.org/#irc://irc.hackint.org/archivebot">#archivebot</a> on hackint. <a href="https://archivebot.readthedocs.io/en/latest/">Issue commands</a> by typing them into the channel. You will need channel operator (@) or voice (+) status to issue archiving jobs; just ask for help or leave a message with the website you want to archive.

--- a/dashboard/dashboard.html
+++ b/dashboard/dashboard.html
@@ -480,6 +480,7 @@ kbd {
 				<li>To skip loading of recent (buffered) log data for jobs, add <kbd><span class="url-q-or-amp">?</span>loadRecent=0</kbd> to the dashboard URL. Inactive jobs will not appear.</li>
 				<li>To append some text to the page title, add <kbd><span class="url-q-or-amp">?</span>title=TEXT</kbd> to the dashboard URL.</li>
 				<li>To override the hostname of the logs server, add <kbd><span class="url-q-or-amp">?</span>host=TEXT</kbd> to the dashboard URL.</li>
+				<li>To override the port of the recent logs server, add <kbd><span class="url-q-or-amp">?</span>port=TEXT</kbd> to the dashboard URL.</li>
 				<li>To view the first two JSON messages of the logs stream, add <kbd><span class="url-q-or-amp">?</span>dumpMax=2</kbd> to the dashboard URL.</li>
 				<li>To enable debug messages in the browser console, add <kbd><span class="url-q-or-amp">?</span>debug=1</kbd> to the dashboard URL.</li>
 			</ul>

--- a/dashboard/dashboard.html
+++ b/dashboard/dashboard.html
@@ -421,9 +421,9 @@ kbd {
 				Each job has a header with the URL, note, request/queue stats, options and an identifier.
 			</p>
 			<p>
-				To show or hide a job, click anywhere on its stats line.
+				To show or hide a job, click anywhere on its header.
 
-				The color coding for the job stats line is:
+				The color coding for the job header is:
 					in progress,
 					<span class="job-info-done">finished normally</span>,
 					<span class="job-info-aborted">finished with abort</span>,

--- a/dashboard/dashboard.html
+++ b/dashboard/dashboard.html
@@ -391,6 +391,12 @@ kbd {
 	top: 0;
 }
 </style>
+<style id="hide-headers">
+.log-container:has(.log-window-hidden) {
+	display: none;
+	content-visibility: hidden;
+}
+</style>
 <div id="context-menu"></div>
 <div class="padded-page">
 	<div class="header">
@@ -401,6 +407,8 @@ kbd {
 			Logs <input id="filter-box" type="text" size="21" title="Show logs for jobs matching this regular expression. For example ^https?://.*">
 			<input id="set-filter-all" onclick="ds.setFilter('');" type="button" value="All"  class="button">
 			<input id="set-filter-none" onclick="ds.setFilter('^$');" type="button" value="None" class="button">
+			<input type="checkbox" id="show-all-headers" onclick="ds.showAllHeaders(this.checked);">
+			<label for="show-all-headers">All headers</label>
 		</div>
 		<div id="header-right">
 			<div id="meta-info"><span class="adbox">😊</span></div>
@@ -449,6 +457,7 @@ kbd {
 				<li><kbd>f</kbd> - move focus to filter box
 				<li><kbd>i</kbd> - use the initial job log filter
 				<li><kbd>v</kbd> - open the job URL of the first-shown job log
+				<li><kbd>h</kbd> - show/hide headers for hidden job logs
 				<li><kbd>?</kbd> - show/hide help text
 			</ul>
 			<p>
@@ -465,6 +474,7 @@ kbd {
 			</p>
 			<ul>
 				<li>To specify an initial filter, add <kbd><span class="url-q-or-amp">?</span>initialFilter=TEXT</kbd> to the dashboard URL. The default is <kbd>^$</kbd>.</li>
+				<li>To initially hide headers for hidden job logs, add <kbd><span class="url-q-or-amp">?</span>showAllHeaders=0</kbd> to the dashboard URL. The default is to show them.</li>
 				<li>To retain more lines in the log windows, add <kbd><span class="url-q-or-amp">?</span>historyLines=1000</kbd> to the dashboard URL. The default is <code>500</code>, or <code>250</code> on mobile.</li>
 				<li>To update the dashboard more frequently, add <kbd><span class="url-q-or-amp">?</span>batchTimeWhenVisible=33</kbd> to the dashboard URL. The default is <code>125</code> (8 Hz).</li>
 				<li>To skip loading of recent (buffered) log data for jobs, add <kbd><span class="url-q-or-amp">?</span>loadRecent=0</kbd> to the dashboard URL. Inactive jobs will not appear.</li>

--- a/dashboard/dashboard.html
+++ b/dashboard/dashboard.html
@@ -398,7 +398,7 @@ kbd {
 			<a href="https://wiki.archiveteam.org/index.php?title=ArchiveBot" class="underlined-a">ArchiveBot</a>
 			tracking <span id="num-crawls">0</span> crawls.
 			See also <a href="pipelines" class="underlined-a">pipeline</a> or <a href="logs/recent" class="underlined-a">job</a> reports.
-			Show: <input id="filter-box" type="text" size="21">
+			Logs <input id="filter-box" type="text" size="21" title="Show logs for jobs matching this regular expression. For example ^https?://.*">
 			<input onclick="ds.setFilter('');" type="button" value="  All  " class="button">
 			<input onclick="ds.setFilter('^$');" type="button" value="None" class="button">
 		</div>
@@ -442,12 +442,12 @@ kbd {
 				Keyboard shortcuts:
 			</p>
 			<ul>
-				<li><kbd>j</kbd> - show next job window
-				<li><kbd>k</kbd> - show previous job window
-				<li><kbd>a</kbd> - show all job windows
-				<li><kbd>n</kbd> - hide all job windows
+				<li><kbd>j</kbd> - show next job log
+				<li><kbd>k</kbd> - show previous job log
+				<li><kbd>a</kbd> - show all job log
+				<li><kbd>n</kbd> - hide all job log
 				<li><kbd>f</kbd> - move focus to filter box
-				<li><kbd>v</kbd> - open the job URL of the first-shown job window
+				<li><kbd>v</kbd> - open the job URL of the first-shown job log
 				<li><kbd>?</kbd> - show/hide help text
 			</ul>
 			<p>

--- a/dashboard/dashboard.html
+++ b/dashboard/dashboard.html
@@ -579,7 +579,7 @@ kbd {
 				<li>To enable debug messages in the browser console, add <kbd><span class="url-q-or-amp">?</span>debug=1</kbd> to the dashboard URL.</li>
 			</ul>
 			<p>
-				To use ArchiveBot, drop by <a href="https://webirc.hackint.org/#irc://irc.hackint.org/archivebot">#archivebot</a> on hackint. <a href="https://archivebot.readthedocs.io/en/latest/">Issue commands</a> by typing them into the channel. You will need channel operator (@) or voice (+) status to issue archiving jobs; just ask for help or leave a message with the website you want to archive.
+				To use ArchiveBot, drop by <a href="https://chat.hackint.org/?join=archivebot">#archivebot</a> on hackint. <a href="https://archivebot.readthedocs.io/en/latest/">Issue commands</a> by typing them into the channel. You will need channel operator (@) or voice (+) status to issue archiving jobs; just ask for help or leave a message with the website you want to archive.
 			</p>
 			<p>
 				These <a href="https://github.com/ArchiveTeam/ArchiveBot/tree/master/db/ignore_patterns">ignore sets</a> are available for crawls. The <a href="https://github.com/ArchiveTeam/ArchiveBot/blob/master/db/ignore_patterns/global.json">global</a> ignore set automatically applies to all crawls.

--- a/dashboard/dashboard.html
+++ b/dashboard/dashboard.html
@@ -448,7 +448,21 @@ kbd {
 			<a href="https://wiki.archiveteam.org/index.php?title=ArchiveBot" class="underlined-a">ArchiveBot</a>
 			tracking <span id="num-crawls">0</span> crawls.
 			See also <a href="pipelines" class="underlined-a">pipeline</a> or <a href="logs/recent" class="underlined-a">job</a> reports.
-			Logs <input id="filter-box" type="text" size="21" title="Show logs for jobs matching this regular expression. For example ^https?://.*">
+			<details class="drop-down">
+			<summary>Logs</summary>
+			<div id="filter-types">
+			Search:<br>
+			<input type="checkbox" id="filter-job-id" onclick="ds.jobsRenderer.applyFilter();" checked>
+			<label class="filter-job" for="filter-job-id">ID</label><br>
+			<input type="checkbox" id="filter-job-url" onclick="ds.jobsRenderer.applyFilter();" accesskey="u" checked>
+			<label class="filter-job" for="filter-job-url">URL</label><br>
+			<input type="checkbox" id="filter-job-note" onclick="ds.jobsRenderer.applyFilter();" accesskey="e" checked>
+			<label class="filter-job" for="filter-job-note" title="Explain">Note</label><br>
+			<input type="checkbox" id="filter-job-pipeline" onclick="ds.jobsRenderer.applyFilter();" accesskey="p" checked>
+			<label class="filter-job" for="filter-job-pipeline">Pipe</label><br>
+			</div>
+			</details>
+			<input id="filter-box" type="text" size="21" title="Show logs for jobs matching this regular expression. For example ^https?://.*">
 			<input id="set-filter-all" onclick="ds.setFilter('');" type="button" value="All"  class="button">
 			<input id="set-filter-none" onclick="ds.setFilter('^$');" type="button" value="None" class="button">
 			<input type="checkbox" id="show-all-headers" onclick="ds.showAllHeaders(this.checked);">
@@ -521,6 +535,9 @@ kbd {
 				<li><kbd>b</kbd> - show/hide header+log for failed jobs
 				<li><kbd>c</kbd> - show/hide header+log for fatal jobs
 				<li><kbd>s</kbd> - show/hide header+log for aborted jobs
+				<li><kbd>u</kbd> - enable/disable URL search for job log filter
+				<li><kbd>e</kbd> - enable/disable note/explain search for job log filter
+				<li><kbd>p</kbd> - enable/disable pipeline search for job log filter
 				<li><kbd>?</kbd> - show/hide help text
 			</ul>
 			<p>
@@ -537,6 +554,12 @@ kbd {
 			</p>
 			<ul>
 				<li>To specify an initial filter, add <kbd><span class="url-q-or-amp">?</span>initialFilter=TEXT</kbd> to the dashboard URL. The default is <kbd>^$</kbd>.</li>
+				<li>To initially disable filtering by job details, add these to the dashboard URL. The default is to filter by them.
+					<kbd><span class="url-q-or-amp">?</span>filterJobID=0</kbd>
+					<kbd><span class="url-q-or-amp">?</span>filterJobURL=0</kbd>
+					<kbd><span class="url-q-or-amp">?</span>filterJobNote=0</kbd>
+					<kbd><span class="url-q-or-amp">?</span>filterJobPipe=0</kbd>
+				</li>
 				<li>To initially hide headers for hidden job logs, add <kbd><span class="url-q-or-amp">?</span>showAllHeaders=0</kbd> to the dashboard URL. The default is to show them.</li>
 				<li>To initially hide different job types, add these to the dashboard URL. The default is to show them.
 					<kbd><span class="url-q-or-amp">?</span>showRunningJobs=0</kbd>

--- a/dashboard/dashboard.html
+++ b/dashboard/dashboard.html
@@ -57,6 +57,11 @@ html, body, .job-ident {
 	font-size: 18px;
 }
 
+.drop-down {
+	display: inline flex;
+	flex-direction: column;
+}
+
 .padded-page {
 	padding: 20px 27px 20px 27px;
 }
@@ -397,6 +402,34 @@ kbd {
 	content-visibility: hidden;
 }
 </style>
+<style id="hide-running">
+.log-container:not(
+	:has(.job-info-done),
+	:has(.job-info-fatal),
+	:has(.job-info-aborted)
+) {
+	display: none;
+	content-visibility: hidden;
+}
+</style>
+<style id="hide-done">
+.log-container:has(.job-info-done) {
+	display: none;
+	content-visibility: hidden;
+}
+</style>
+<style id="hide-fatal">
+.log-container:has(.job-info-fatal) {
+	display: none;
+	content-visibility: hidden;
+}
+</style>
+<style id="hide-aborted">
+.log-container:has(.job-info-aborted) {
+	display: none;
+	content-visibility: hidden;
+}
+</style>
 <div id="context-menu"></div>
 <div class="padded-page">
 	<div class="header">
@@ -409,6 +442,17 @@ kbd {
 			<input id="set-filter-none" onclick="ds.setFilter('^$');" type="button" value="None" class="button">
 			<input type="checkbox" id="show-all-headers" onclick="ds.showAllHeaders(this.checked);">
 			<label for="show-all-headers">All headers</label>
+			<details class="drop-down">
+			<summary>Jobs</summary>
+			<input type="checkbox" id="show-running-jobs" onclick="ds.showRunningJobs(this.checked);" accesskey="r">
+			<label for="show-running-jobs">Running</label><br>
+			<input type="checkbox" id="show-finished-jobs" onclick="ds.showFinishedJobs(this.checked);" accesskey="d">
+			<label class="job-info-done" for="show-finished-jobs">Finished</label><br>
+			<input type="checkbox" id="show-fatal-jobs" onclick="ds.showFatalJobs(this.checked);" accesskey="c">
+			<label class="job-info-fatal" for="show-fatal-jobs">Fatal</label><br>
+			<input type="checkbox" id="show-aborted-jobs" onclick="ds.showAbortedJobs(this.checked);" accesskey="s">
+			<label class="job-info-aborted" for="show-aborted-jobs">Aborted</label><br>
+			</details>
 		</div>
 		<div id="header-right">
 			<div id="meta-info"><span class="adbox">😊</span></div>
@@ -458,6 +502,10 @@ kbd {
 				<li><kbd>i</kbd> - use the initial job log filter
 				<li><kbd>v</kbd> - open the job URL of the first-shown job log
 				<li><kbd>h</kbd> - show/hide headers for hidden job logs
+				<li><kbd>r</kbd> - show/hide header+log for running jobs
+				<li><kbd>d</kbd> - show/hide header+log for finished jobs
+				<li><kbd>c</kbd> - show/hide header+log for fatal jobs
+				<li><kbd>s</kbd> - show/hide header+log for aborted jobs
 				<li><kbd>?</kbd> - show/hide help text
 			</ul>
 			<p>
@@ -475,6 +523,12 @@ kbd {
 			<ul>
 				<li>To specify an initial filter, add <kbd><span class="url-q-or-amp">?</span>initialFilter=TEXT</kbd> to the dashboard URL. The default is <kbd>^$</kbd>.</li>
 				<li>To initially hide headers for hidden job logs, add <kbd><span class="url-q-or-amp">?</span>showAllHeaders=0</kbd> to the dashboard URL. The default is to show them.</li>
+				<li>To initially hide different job types, add these to the dashboard URL. The default is to show them.
+					<kbd><span class="url-q-or-amp">?</span>showRunningJobs=0</kbd>
+					<kbd><span class="url-q-or-amp">?</span>showFinishedJobs=0</kbd>
+					<kbd><span class="url-q-or-amp">?</span>showFatalJobs=0</kbd>
+					<kbd><span class="url-q-or-amp">?</span>showAbortedJobs=0</kbd>
+				</li>
 				<li>To retain more lines in the log windows, add <kbd><span class="url-q-or-amp">?</span>historyLines=1000</kbd> to the dashboard URL. The default is <code>500</code>, or <code>250</code> on mobile.</li>
 				<li>To update the dashboard more frequently, add <kbd><span class="url-q-or-amp">?</span>batchTimeWhenVisible=33</kbd> to the dashboard URL. The default is <code>125</code> (8 Hz).</li>
 				<li>To skip loading of recent (buffered) log data for jobs, add <kbd><span class="url-q-or-amp">?</span>loadRecent=0</kbd> to the dashboard URL. Inactive jobs will not appear.</li>

--- a/dashboard/dashboard.html
+++ b/dashboard/dashboard.html
@@ -133,6 +133,10 @@ html, body, .job-ident {
 	color: #DD0000 !important;
 }
 
+.job-info-failed {
+	color: #CC7676 !important;
+}
+
 .inline-stat {
 	/* Needed for 'Align!' feature */
 	display: inline-block;
@@ -405,6 +409,7 @@ kbd {
 <style id="hide-running">
 .log-container:not(
 	:has(.job-info-done),
+	:has(.job-info-failed),
 	:has(.job-info-fatal),
 	:has(.job-info-aborted)
 ) {
@@ -414,6 +419,12 @@ kbd {
 </style>
 <style id="hide-done">
 .log-container:has(.job-info-done) {
+	display: none;
+	content-visibility: hidden;
+}
+</style>
+<style id="hide-failed">
+.log-container:has(.job-info-failed) {
 	display: none;
 	content-visibility: hidden;
 }
@@ -448,6 +459,8 @@ kbd {
 			<label for="show-running-jobs">Running</label><br>
 			<input type="checkbox" id="show-finished-jobs" onclick="ds.showFinishedJobs(this.checked);" accesskey="d">
 			<label class="job-info-done" for="show-finished-jobs">Finished</label><br>
+			<input type="checkbox" id="show-failed-jobs" onclick="ds.showFailedJobs(this.checked);" accesskey="b">
+			<label class="job-info-failed" for="show-failed-jobs">Failed</label><br>
 			<input type="checkbox" id="show-fatal-jobs" onclick="ds.showFatalJobs(this.checked);" accesskey="c">
 			<label class="job-info-fatal" for="show-fatal-jobs">Fatal</label><br>
 			<input type="checkbox" id="show-aborted-jobs" onclick="ds.showAbortedJobs(this.checked);" accesskey="s">
@@ -478,6 +491,7 @@ kbd {
 				The color coding for the job header is:
 					in progress,
 					<span class="job-info-done">finished normally</span>,
+					<span class="job-info-failed">finished with failure</span>,
 					<span class="job-info-aborted">finished with abort</span>,
 					<span class="job-info-fatal">finished with fatal exception</span>.
 			</p>
@@ -504,6 +518,7 @@ kbd {
 				<li><kbd>h</kbd> - show/hide headers for hidden job logs
 				<li><kbd>r</kbd> - show/hide header+log for running jobs
 				<li><kbd>d</kbd> - show/hide header+log for finished jobs
+				<li><kbd>b</kbd> - show/hide header+log for failed jobs
 				<li><kbd>c</kbd> - show/hide header+log for fatal jobs
 				<li><kbd>s</kbd> - show/hide header+log for aborted jobs
 				<li><kbd>?</kbd> - show/hide help text
@@ -526,6 +541,7 @@ kbd {
 				<li>To initially hide different job types, add these to the dashboard URL. The default is to show them.
 					<kbd><span class="url-q-or-amp">?</span>showRunningJobs=0</kbd>
 					<kbd><span class="url-q-or-amp">?</span>showFinishedJobs=0</kbd>
+					<kbd><span class="url-q-or-amp">?</span>showFailedJobs=0</kbd>
 					<kbd><span class="url-q-or-amp">?</span>showFatalJobs=0</kbd>
 					<kbd><span class="url-q-or-amp">?</span>showAbortedJobs=0</kbd>
 				</li>

--- a/dashboard/dashboard3.html
+++ b/dashboard/dashboard3.html
@@ -156,7 +156,7 @@ a.job-log-line-url {
 		If your adblocker is enabled for this domain, you will see slower performance, and some URLs will not be displayed.
 	</p>
 	<p>
-		To use ArchiveBot, drop by <a href="https://webirc.hackint.org/#irc://irc.hackint.org/archivebot">#archivebot</a> on hackint.  <a href="http://archivebot.readthedocs.org/en/latest/">Issue commands</a> by typing them into the channel.  You will need channel operator (@) or voice (+) status to issue archiving jobs; just ask for help or leave a message with the website you want to archive.
+		To use ArchiveBot, drop by <a href="https://chat.hackint.org/?join=archivebot">#archivebot</a> on hackint.  <a href="http://archivebot.readthedocs.org/en/latest/">Issue commands</a> by typing them into the channel.  You will need channel operator (@) or voice (+) status to issue archiving jobs; just ask for help or leave a message with the website you want to archive.
 	</p>
 	<p>
 		These <a href="https://github.com/ArchiveTeam/ArchiveBot/tree/master/db/ignore_patterns">ignore sets</a> are available for crawls.  The <a href="https://github.com/ArchiveTeam/ArchiveBot/blob/master/db/ignore_patterns/global.json">global</a> ignore set automatically applies to all crawls.

--- a/dashboard/finished.html
+++ b/dashboard/finished.html
@@ -43,7 +43,6 @@ html, body {
 	<script>
 		var table;
 		var reloadInterval = 600 * 1000; // 10 minutes
-		var timestampThreshold = 60 * 5 * 1000;
 		var showNicks = (location.search.indexOf("?showNicks=") != -1) || (location.search.indexOf("&showNicks=") != -1);
 		function initTable() {
 			if (showNicks) $('#queued_by').show();

--- a/dashboard/pipeline.html
+++ b/dashboard/pipeline.html
@@ -89,6 +89,7 @@ html, body {
 					"url" : "/pipelines",
 					"dataSrc" : "pipelines"
 				},
+				"rowId" : "id",
 				"columns" : [ {
 					"data" : "id"
 				}, {

--- a/dashboard/pipeline.html
+++ b/dashboard/pipeline.html
@@ -82,12 +82,20 @@ html, body {
 			return !o || o.trim().length === 0;
 		}
 
+		function getSearchParam() {
+			const params = new URLSearchParams(document.location.search);
+			return params.get("initialFilter");
+		}
+
 		function initTable() {
 			table = $('#pipeline_table').DataTable({
 				"paging" : false,
 				"ajax" : {
 					"url" : "/pipelines",
 					"dataSrc" : "pipelines"
+				},
+				"search": {
+					"search": getSearchParam(),
 				},
 				"rowId" : "id",
 				"columns" : [ {

--- a/dashboard/pipeline.html
+++ b/dashboard/pipeline.html
@@ -97,6 +97,7 @@ html, body {
 				"search": {
 					"search": getSearchParam(),
 				},
+				"searchDelay": 500,
 				"rowId" : "id",
 				"columns" : [ {
 					"data" : "id"
@@ -159,6 +160,20 @@ html, body {
 					"data": "status",
 					"defaultContent": "(unknown)"
 				}, ]
+			});
+
+			table.on('search.dt', function () {
+				let timeout = null;
+				clearTimeout(timeout);
+				timeout = setTimeout(() => {
+					clearTimeout(timeout);
+					let url = new URL(document.URL);
+					if (table.search() !== url.searchParams.get('initialFilter')) {
+						url.searchParams.set('initialFilter', table.search());
+						history.pushState(undefined, undefined, url.toString());
+						console.log(url.toString())
+					}
+				}, 500);
 			});
 
 			setTimeout(reloadTable, reloadInterval);

--- a/dashboard/resources/feed.rb
+++ b/dashboard/resources/feed.rb
@@ -34,6 +34,7 @@ class Feed < Webmachine::Resource
   end
 
   def to_json
+    response.headers['Access-Control-Allow-Origin'] = '*'
     prepped_messages.to_json
   end
 

--- a/dashboard/resources/pipeline.rb
+++ b/dashboard/resources/pipeline.rb
@@ -15,6 +15,7 @@ class Pipeline < Webmachine::Resource
   end
 
   def to_json
+    response.headers['Access-Control-Allow-Origin'] = '*'
     { 'pipelines' => PipelineCollection.new(self.class.redis).to_a }.to_json
   end
 


### PR DESCRIPTION
These changes include lots of quality-of-life features and fixes:

- **Document the job header and its contents**
- **Refer to the job header rather than stats line**
- **Clarify that the filter operates on job logs and is a regex**
- **Document the title URL parameter**
- **Document the host URL parameter**
- **Document the dumpMax URL parameter**
- **Document the debug URL parameter**
- **Add job notes to job URL title**
- **Document the mouseover info for the URL and queue count**
- **Compile the filter regex only once when filtering jobs**
- **Allow filtering jobs by the person who started the job**
- **Add identifiers for the filter modification buttons**
- **Add a button and key to revert to the initial filter**
- **Allow hiding the job headers for hidden job logs**
- **Add an option to specify the port for the recent logs**
- **Add an option to specify the URL for the logs stream**
- **Add a slight delay when typing into the job log filter**
- **Allow hiding jobs based on their status**
- **Fix detection of finished jobs**
- **Detect jobs that failed and allow filtering them out**

Happy to fix or remove anything from this if needed.