### PR TITLE
autocapitalize="none" on dashboard search

### DIFF
--- a/dashboard/dashboard3.html
+++ b/dashboard/dashboard3.html
@@ -173,7 +173,7 @@ a.job-log-line-url {
 
 <div>
 	<label for="filterBox">Filter:</label>
-	<input type="search" ng-model="filterQuery" id="filterBox" placeholder="{{ :: showNicks ? 'URL, ident, or nick' : 'URL or ident'}}">
+	<input type="search" ng-model="filterQuery" id="filterBox" autocapitalize="none" placeholder="{{ :: showNicks ? 'URL, ident, or nick' : 'URL or ident'}}">
 	<button class="btn btn-default" ng-click="applyFilterQuery('')"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span> Clear</button>
 </div>
 


### PR DESCRIPTION
stops the first letter being autocapitalized on mobile (which causes you to get no matches for a URL)