### PR TITLE
Add additional wordpress.com-specific ignores to igset blogs

### DIFF
--- a/db/ignore_patterns/blogs.json
+++ b/db/ignore_patterns/blogs.json
@@ -34,6 +34,8 @@
         "^https?://[^\\.]+\\.dreamwidth\\.org/.+[\\?&]mode=reply",
         "[?&]SuperSocializerAuth=(LiveJournal|Twitch|Twitter|Xing)(&|$)",
         "^https?://wordpress\\.com/log-in\\?",
+        "^https?://wordpress\\.com/abuse/",
+        "^https?://wordpress\\.com/reader/blogs/\\d+/posts/\\d+$",
         "^https?://[^/]*/\\?blackhole=[^&]+$"
     ],
     "type": "ignore_patterns"


### PR DESCRIPTION
`^https?://wordpress\.com/abuse/` covers a report abuse form.

`^https?://wordpress\.com/reader/blogs/\d+/posts/\d+$` redirects (using JS) to a wordpress.com sign-in page, and doesn't contain any other useful per-page data.