### PR TITLE
Add `--no-cookies` to flags

### DIFF
--- a/bot/job_options_parser.rb
+++ b/bot/job_options_parser.rb
@@ -24,7 +24,7 @@ class JobOptionsParser
         b[0] = (case b[0]
                when '--ignoresets','--ignore_sets','--ignoreset','--ignore-set','--ignore_set','--ig-set','--igset' then '--ignore-sets'
                when '--nooffsitelinks','--no-offsite','--nooffsite' then '--no-offsite-links'
-               when '--nocookies', then '--no-cookies'
+               when '--nocookies' then '--no-cookies'
                when '--useragentalias','--user-agent','--useragent' then '--user-agent-alias'
                when '--concurrent' then '--concurrency'
                when '--reason' then '--explain'

--- a/bot/job_options_parser.rb
+++ b/bot/job_options_parser.rb
@@ -5,7 +5,7 @@ class JobOptionsParser
   def initialize
     @parser = Trollop::Parser.new do
       opt :no_offsite_links, 'Do not fetch offsite links'
-      opt :no_save_cookies, 'Do not save cookies'
+      opt :no_cookies, 'Do not use cookies'
       opt :youtube_dl, 'Use youtube-dl on grabbed pages'
       opt :ignore_sets, 'Ignore sets to apply', :type => :string
       opt :pipeline, 'Run job on this pipeline', :type => :string
@@ -24,7 +24,7 @@ class JobOptionsParser
         b[0] = (case b[0]
                when '--ignoresets','--ignore_sets','--ignoreset','--ignore-set','--ignore_set','--ig-set','--igset' then '--ignore-sets'
                when '--nooffsitelinks','--no-offsite','--nooffsite' then '--no-offsite-links'
-               when '--nosavecookies','--no-cookies','--nocookies' then '--no-save-cookies'
+               when '--nocookies', then '--no-cookies'
                when '--useragentalias','--user-agent','--useragent' then '--user-agent-alias'
                when '--concurrent' then '--concurrency'
                when '--reason' then '--explain'

--- a/bot/job_options_parser.rb
+++ b/bot/job_options_parser.rb
@@ -5,6 +5,7 @@ class JobOptionsParser
   def initialize
     @parser = Trollop::Parser.new do
       opt :no_offsite_links, 'Do not fetch offsite links'
+      opt :no_save_cookies, 'Do not save cookies'
       opt :youtube_dl, 'Use youtube-dl on grabbed pages'
       opt :ignore_sets, 'Ignore sets to apply', :type => :string
       opt :pipeline, 'Run job on this pipeline', :type => :string
@@ -23,6 +24,7 @@ class JobOptionsParser
         b[0] = (case b[0]
                when '--ignoresets','--ignore_sets','--ignoreset','--ignore-set','--ignore_set','--ig-set','--igset' then '--ignore-sets'
                when '--nooffsitelinks','--no-offsite','--nooffsite' then '--no-offsite-links'
+               when '--nosavecookies','--no-cookies','--nocookies' then '--no-save-cookies'
                when '--useragentalias','--user-agent','--useragent' then '--user-agent-alias'
                when '--concurrent' then '--concurrency'
                when '--reason' then '--explain'

--- a/bot/pipeline_options.rb
+++ b/bot/pipeline_options.rb
@@ -17,6 +17,11 @@ module PipelineOptions
       messages << 'offsite links: no'
     end
 
+    if params[:no_save_cookies]
+      job.no_save_cookies!
+      messages << 'save cookies: no'
+    end
+
     if !messages.empty?
       reply m, "Options: #{messages.join('; ')}"
     end

--- a/bot/pipeline_options.rb
+++ b/bot/pipeline_options.rb
@@ -17,9 +17,9 @@ module PipelineOptions
       messages << 'offsite links: no'
     end
 
-    if params[:no_save_cookies]
-      job.no_save_cookies!
-      messages << 'save cookies: no'
+    if params[:no_cookies]
+      job.no_cookies!
+      messages << 'use cookies: no'
     end
 
     if !messages.empty?

--- a/doc/commands.rst
+++ b/doc/commands.rst
@@ -67,6 +67,9 @@ Accepted parameters
 
     Aliases: ``--nooffsitelinks``, ``--no-offsite``, ``--nooffsite``
 
+``--no-save-cookies``
+    do not save cookies to a cookie jar
+
 ``--user-agent-alias ALIAS``
     specify a user-agent to use::
 

--- a/doc/commands.rst
+++ b/doc/commands.rst
@@ -67,8 +67,8 @@ Accepted parameters
 
     Aliases: ``--nooffsitelinks``, ``--no-offsite``, ``--nooffsite``
 
-``--no-save-cookies``
-    do not save cookies to a cookie jar
+``--no-cookies``
+    do not use cookies for each request
 
 ``--user-agent-alias ALIAS``
     specify a user-agent to use::

--- a/lib/job.rb
+++ b/lib/job.rb
@@ -380,8 +380,8 @@ class Job < Struct.new(:uri, :redis)
     redis.hset(ident, 'no_offsite_links', true)
   end
 
-  def no_save_cookies!
-    redis.hset(ident, 'no_save_cookies', true)
+  def no_cookies!
+    redis.hset(ident, 'no_cookies', true)
   end
 
   def yahoo

--- a/lib/job.rb
+++ b/lib/job.rb
@@ -380,6 +380,10 @@ class Job < Struct.new(:uri, :redis)
     redis.hset(ident, 'no_offsite_links', true)
   end
 
+  def no_save_cookies!
+    redis.hset(ident, 'no_save_cookies', true)
+  end
+
   def yahoo
     silently do
       set_delay(0, 0)

--- a/pipeline/archivebot/seesaw/tasks.py
+++ b/pipeline/archivebot/seesaw/tasks.py
@@ -140,7 +140,7 @@ class GetItemFromQueue(RetryableTask):
                 item['url_file'] = job_data.get('url_file')
                 item['user_agent'] = job_data.get('user_agent')
                 item['no_offsite_links'] = job_data.get('no_offsite_links')
-                item['no_save_cookies'] = job_data.get('no_save_cookies')
+                item['no_cookies'] = job_data.get('no_cookies')
                 item['youtube_dl'] = job_data.get('youtube_dl')
 
                 item.log_output('Received item %s.' % ident)

--- a/pipeline/archivebot/seesaw/tasks.py
+++ b/pipeline/archivebot/seesaw/tasks.py
@@ -140,6 +140,7 @@ class GetItemFromQueue(RetryableTask):
                 item['url_file'] = job_data.get('url_file')
                 item['user_agent'] = job_data.get('user_agent')
                 item['no_offsite_links'] = job_data.get('no_offsite_links')
+                item['no_save_cookies'] = job_data.get('no_save_cookies')
                 item['youtube_dl'] = job_data.get('youtube_dl')
 
                 item.log_output('Received item %s.' % ident)

--- a/pipeline/archivebot/seesaw/wpull.py
+++ b/pipeline/archivebot/seesaw/wpull.py
@@ -50,7 +50,9 @@ def make_args(item, default_user_agent, wpull_exe, youtube_dl_exe, finished_warc
         '--youtube-dl-exe', youtube_dl_exe
     ]
 
-    if not item.get('no_save_cookies'):
+    if item.get('no_save_cookies'):
+        args.append('--no-cookies')
+    else:
         add_args(args, ['--save-cookies', '%(cookie_jar)s'], item)
 
     if item['url'].startswith("http://www.reddit.com/") or \

--- a/pipeline/archivebot/seesaw/wpull.py
+++ b/pipeline/archivebot/seesaw/wpull.py
@@ -22,7 +22,6 @@ def make_args(item, default_user_agent, wpull_exe, youtube_dl_exe, finished_warc
         '-o', '%(item_dir)s/wpull.log' % item,
         '--database', '%(item_dir)s/wpull.db' % item,
         '--html-parser', 'libxml2-lxml',
-        '--save-cookies', '%(cookie_jar)s' % item,
         '--no-check-certificate',
         '--no-strong-crypto',
         '--delete-after',
@@ -50,6 +49,9 @@ def make_args(item, default_user_agent, wpull_exe, youtube_dl_exe, finished_warc
         '--max-redirect', '8',
         '--youtube-dl-exe', youtube_dl_exe
     ]
+
+    if not item.get('no_save_cookies'):
+        add_args(args, ['--save-cookies', '%(cookie_jar)s'], item)
 
     if item['url'].startswith("http://www.reddit.com/") or \
        item['url'].startswith("https://www.reddit.com/"):

--- a/pipeline/archivebot/seesaw/wpull.py
+++ b/pipeline/archivebot/seesaw/wpull.py
@@ -50,7 +50,7 @@ def make_args(item, default_user_agent, wpull_exe, youtube_dl_exe, finished_warc
         '--youtube-dl-exe', youtube_dl_exe
     ]
 
-    if item.get('no_save_cookies'):
+    if item.get('no_cookies'):
         args.append('--no-cookies')
     else:
         add_args(args, ['--save-cookies', '%(cookie_jar)s'], item)

--- a/spec/bot/job_options_parser_spec.rb
+++ b/spec/bot/job_options_parser_spec.rb
@@ -53,8 +53,8 @@ describe JobOptionsParser do
     expect(parser.parse('--concurrency=4')[:concurrency]).to eq(4)
   end
 
-  it 'recognizes --no-save-cookies' do
-    expect(parser.parse('--no-save-cookies')[:no_save_cookies]).to eq(true)
+  it 'recognizes --no-cookies' do
+    expect(parser.parse('--no-cookies')[:no_cookies]).to eq(true)
   end
 
   describe 'when unknown options are present' do

--- a/spec/bot/job_options_parser_spec.rb
+++ b/spec/bot/job_options_parser_spec.rb
@@ -53,6 +53,10 @@ describe JobOptionsParser do
     expect(parser.parse('--concurrency=4')[:concurrency]).to eq(4)
   end
 
+  it 'recognizes --no-save-cookies' do
+    expect(parser.parse('--no-save-cookies')[:no_save_cookies]).to eq(true)
+  end
+
   describe 'when unknown options are present' do
     it 'raises UnknownOptionError' do
       expect(lambda { parser.parse('--foo=bar') }).to raise_error(JobOptionsParser::UnknownOptionError)


### PR DESCRIPTION
This patch will not save cookies to the cookie jar and won't retain cookies per request.


This is useful for sites like Gyazo, when processing a list of URLs. On the first image request, the site serves the direct image. However, on subsequent requests, it starts returning an HTML/JavaScript page instead, and that page then re-requests the same URL to get the actual image. By not sending cookies, Gyazo serves the images directly without triggering the extra JavaScript logic that would otherwise attempt to fetch the same URL again (which AB doesn't pick up), and this is necessary to obtain the actual image from a Gyazo URL.