### PR TITLE
uploader: Safeguard against rsync localhost IPv6 targets, and update documentation

### DIFF
--- a/uploader/uploader.py
+++ b/uploader/uploader.py
@@ -3,7 +3,7 @@
 """uploader.py: upload WARC files toward the Internet Archive
 
 rsync mode (RSYNC_URL set): upload everything to an rsync endpoint
-such as fos.
+such as ArchiveTeam targets.
 
 s3 mode (S3_URL set): upload everything directly to the Internet Archive
 

--- a/uploader/uploader.py
+++ b/uploader/uploader.py
@@ -36,7 +36,8 @@ class Params:
 
         self.url = os.environ.get('RSYNC_URL')
         if self.url != None:
-            if '/localhost' in self.url or '/127.' in self.url:
+            local_urls = ['/localhost','/127.','/[::1]']
+            if any(local_url in self.url for local_url in local_urls):
                 raise RuntimeError('Won\'t let you upload to localhost because I '
                                    'remove files after uploading them, and you '
                                    'might be uploading to the same directory')


### PR DESCRIPTION
The commit safeguards against uploads to [::1], and replaces "fos" with "ArchiveTeam targets"