### PR TITLE
bot: !whereis reply for jobs on a queue.

### DIFF
--- a/bot/brain.rb
+++ b/bot/brain.rb
@@ -218,6 +218,10 @@ class Brain
   def whereis(m, job)
     pipeline = PipelineInfo.new(job.redis).from_pipeline_id(job.pipeline_id)
 
+    if job.pending?
+      reply m, %Q{Job #{job.ident} is on a queue.}
+    end
+
     if pipeline.nickname.nil?
       reply m, %Q{Job #{job.ident} is not on a pipeline.}
     else


### PR DESCRIPTION
Have the IRC bot send a message for the `!whereis` command when the job is on a queue, rather than on a pipeline.

Closes #292.